### PR TITLE
widget doesn't load if "dest" is empty

### DIFF
--- a/view/frontend/web/js/widget-js.js
+++ b/view/frontend/web/js/widget-js.js
@@ -81,7 +81,10 @@ define([
                 }
             }
             try{
-                var destNode = document.querySelector(dest);
+                var destNode = srcNode;
+                if (dest){
+                    destNode = document.querySelector(dest);
+                }
             }
             catch(e){
                 console.error(dest + ' is not a valid css selector to write sequra widget to.');


### PR DESCRIPTION
fix "is not a valid css selector to write sequra widget to" if dest is empty