### PR TITLE
Fix compatibilitiy with PHP 7.4 and add plugin_version to order request

### DIFF
--- a/Model/Api/Builders/CreateOrderRequestBuilder.php
+++ b/Model/Api/Builders/CreateOrderRequestBuilder.php
@@ -459,7 +459,7 @@ class CreateOrderRequestBuilder implements \SeQura\Core\BusinessLogic\Domain\Ord
         return [
             'name' => 'magento2',
             'version' => $this->productMetadata->getVersion(),
-            'integration_version' => $this->moduleResource->getDbVersion('Sequra_Core'),
+            'plugin_version' => $this->moduleResource->getDbVersion('Sequra_Core'),
             'uname' => php_uname(),
             'db_name' => !empty($connectionData['model']) ? $connectionData['model'] : 'mysql',
             'db_version' => $this->sqlVersionProvider->getSqlVersion(),

--- a/Services/BusinessLogic/Utility/SeQuraTranslationProvider.php
+++ b/Services/BusinessLogic/Utility/SeQuraTranslationProvider.php
@@ -40,8 +40,7 @@ class SeQuraTranslationProvider
      */
     public function translate(string $text, ...$arguments): Phrase
     {
-        $locale = $this->session->getUser() ?
-            $this->session->getUser()->getInterfaceLocale() : null;
+        $locale = ($user = $this->session->getUser()) ? $user->getInterfaceLocale(): null;
         if ($locale && !self::$englishTranslation) {
             $filePath = $this->moduleDirReader->getModuleDir('i18n', 'Sequra_Core') . '/' . $locale . '.csv';
             if (!file_exists($filePath)) {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "sequra/integration-core": "v1.0.11",
         "ext-json": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "faf7305667d1102b6c913c54662fc14f",
+    "content-hash": "a1e52d2dfd7feee97c92f6bfcc64538f",
     "packages": [
         {
             "name": "sequra/integration-core",
@@ -615,7 +615,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
@@ -237,6 +237,10 @@ define([
         },
 
         loadSeQuraScript: function () {
+            if (!window.checkoutConfig.payment.sequra_payment.widget_settings.hasOwnProperty('merchant')) {
+                return;
+            }
+
             if (typeof Sequra === "undefined") {
                 let products = [];
                 window.checkoutConfig.payment.sequra_payment.widget_settings.products.forEach((product) => {


### PR DESCRIPTION
 ### What is the goal?

- Add compatibility with PHP 7.4
- Add plugin_version field to order request

 ### How is it being implemented?

- Added one line that was incompatible with PHP 7.4.
- Added plugin_version field to \Sequra\Core\Model\Api\Builders\CreateOrderRequestBuilder::getPlatform method result.

### Does it affect (changes or updates) any sensitive data?

No.

 ### How is it tested?

Manual tests.

 ### How is it going to be deployed?

Standard deployment.
