### PR TITLE
Add $formatter property to ConfigProvider

### DIFF
--- a/Gateway/Http/Client/OrderUpdateTransaction.php
+++ b/Gateway/Http/Client/OrderUpdateTransaction.php
@@ -29,6 +29,11 @@ class OrderUpdateTransaction implements ClientInterface
     private $transformService;
 
     /**
+     * @var OrderService
+     */
+    private $orderService;
+
+    /**
      * @param SeQuraTranslationProvider $translationProvider
      * @param TransformEntityService $transformService
      */

--- a/Model/Api/SequraPaymentMethodsService.php
+++ b/Model/Api/SequraPaymentMethodsService.php
@@ -11,6 +11,10 @@ use Sequra\Core\Api\SequraPaymentMethodsInterface;
  */
 class SequraPaymentMethodsService implements SequraPaymentMethodsInterface
 {
+    /**
+     * @var FormValidationSequraPaymentMethodsService
+     */
+    private $paymentMethodsService;
 
     /**
      * SequraPaymentMethodsService constructor.

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -38,6 +38,10 @@ class ConfigProvider implements ConfigProviderInterface
      * @var UrlInterface
      */
     private $urlBuilder;
+    /**
+     * @var \NumberFormatter
+     */
+    private $formatter;
 
     public function __construct(
         \Magento\Framework\App\ScopeResolverInterface $scopeResolver,

--- a/Observer/OrderAddressObserver.php
+++ b/Observer/OrderAddressObserver.php
@@ -35,6 +35,11 @@ class OrderAddressObserver implements ObserverInterface
     private $transformService;
 
     /**
+     * @var OrderService
+     */
+    private $orderService;
+
+    /**
      * @param SeQuraTranslationProvider $translationProvider
      * @param TransformEntityService $transformService
      */

--- a/Observer/OrderCancellationObserver.php
+++ b/Observer/OrderCancellationObserver.php
@@ -30,6 +30,11 @@ class OrderCancellationObserver implements ObserverInterface
     private $translationProvider;
 
     /**
+     * @var OrderService
+     */
+    private $orderService;
+
+    /**
      * @param SeQuraTranslationProvider $translationProvider
      */
     public function __construct(SeQuraTranslationProvider $translationProvider)

--- a/Observer/OrderShipmentObserver.php
+++ b/Observer/OrderShipmentObserver.php
@@ -34,6 +34,11 @@ class OrderShipmentObserver implements ObserverInterface
     private $transformService;
 
     /**
+     * @var OrderService
+     */
+    private $orderService;
+
+    /**
      * @param SeQuraTranslationProvider $translationProvider
      * @param TransformEntityService $transformService
      */

--- a/Plugin/OrderDetails.php
+++ b/Plugin/OrderDetails.php
@@ -35,6 +35,11 @@ class OrderDetails
      */
     protected $translation;
 
+    /**
+     * @var OrderService
+     */
+    private $orderService;
+
     private const statusMap = [
         OrderRequestStates::CONFIRMED => 'sequra.status.paid',
         OrderRequestStates::ON_HOLD => 'sequra.status.pendingReview',

--- a/Services/BusinessLogic/OrderService.php
+++ b/Services/BusinessLogic/OrderService.php
@@ -60,6 +60,10 @@ class OrderService implements ShopOrderService
      * @var SeQuraTranslationProvider
      */
     private $translationProvider;
+    /**
+     * @var SeQuraOrderService
+     */
+    private $sequraOrderService;
 
     public function __construct(
         SearchCriteriaBuilder          $searchOrderCriteriaBuilder,


### PR DESCRIPTION
 ### What is the goal?

Add properties declaration to avoid dynamic properties. In PHP 8.2 causes Exception because creation of dynamic properties are deprecated.


### Does it affect (changes or update) any sensitive data?

No

 ### How is it tested?

1. Go to checkout/cart
2. Exception will be thrown:

```
Deprecated Functionality: Creation of dynamic property Sequra\Core\Model\Ui\ConfigProvider::$formatter is deprecated in /var/www/html/vendor/sequra/magento2-core/Model/Ui/ConfigProvider.php on line 53
```

 ### How is it going to be deployed?

Standard deployment
