### PR TITLE
B/par 360 fix cors error on assets key validation

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sequra_Core" setup_version="2.5.0.0">
+    <module name="Sequra_Core" setup_version="2.5.0.1">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>

--- a/view/adminhtml/web/js/AjaxService.js
+++ b/view/adminhtml/web/js/AjaxService.js
@@ -53,8 +53,9 @@ if (!window.SequraFE) {
          *
          * @param {string} url The URL to call.
          * @param {(error: Record<string, any>) => Promise<void>?} errorCallback
+         * @param {Record<string, string>?} customHeader
          */
-        const get = (url, errorCallback) => call('GET', url, null, errorCallback);
+        const get = (url, errorCallback, customHeader = {}) => call('GET', url, null, errorCallback, customHeader);
 
         /**
          * Performs POST ajax request.

--- a/view/adminhtml/web/js/WidgetSettingsForm.js
+++ b/view/adminhtml/web/js/WidgetSettingsForm.js
@@ -445,8 +445,10 @@ if (!window.SequraFE) {
 
             const validationUrl =
                 `https://${mode}.sequracdn.com/scripts/${merchantId}/${assetsKey}/${methods}_cost.json`;
-
-            return api.get(validationUrl).then(() => true).catch(() => false)
+            customHeader = {
+                'Content-Type': 'text/plain'
+            };
+            return api.get(validationUrl, null, customHeader).then(() => true).catch(() => false)
         }
     }
 


### PR DESCRIPTION
 ### What is the goal?

Some merchant can finish teh plugin configuration due to the fact that the assets key validation is failing.
We found out that it was related to the Content-type header used to make the GET request to the   `https://${mode}.sequracdn.com/scripts/${merchantId}/${assetsKey}/${methods}_cost.json` url.

 ### References
* **Issue:** https://sequra.atlassian.net/browse/LIS-14, https://sequra.atlassian.net/browse/PAR-360

 ### How is it being implemented?

Allow the that AjaxServices get method to receive cutomHeaders and send them from the assetsKey validation method

 ### Opportunistic refactorings

 ### Caveats


### Does it affect (changes or update) any sensitive data?

No

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?
Standard deployment
