### PR TITLE
Don't fail if no order in the list

### DIFF
--- a/Ui/Component/Listing/Column/SequraOrderLink.php
+++ b/Ui/Component/Listing/Column/SequraOrderLink.php
@@ -69,7 +69,9 @@ class SequraOrderLink extends Column
                 $shopOrderReferences[] = $item['increment_id'];
             }
         }
-
+        if (empty($shopOrderReferences)) {
+            return $dataSource;
+        }
         $orders = $this->getOrderService()->getOrderBatchForShopReferences($shopOrderReferences);
         $referenceMap = $this->createReferenceMap($orders);
 


### PR DESCRIPTION
 ### What is the goal?

Fix sql error when in backoffice order management grid there is no order to show.

 ### References
* **Issue:** LIS-15

## How is it being implemented?
return if no order

### Opportunistic refactorings

 ### Caveats

### Does it affect (changes or update) any sensitive data?
No
 ### How is it tested?
Manual tests
 ### How is it going to be deployed?
Standard deployment
