### PR TITLE
Fix widget amount

### DIFF
--- a/Block/WidgetInitializer.php
+++ b/Block/WidgetInitializer.php
@@ -174,7 +174,7 @@ class WidgetInitializer extends Template
 
         $config = $this->widgetConfigService->getData($this->_storeManager->getStore()->getId());
 
-        return $config ? array_merge($config, ['amount' => $amount, 'action_name' => $actionName]) : [];
+        return $config ? array_merge($config, ['amount' => (int)round($amount), 'action_name' => $actionName]) : [];
     }
 
     /**

--- a/Plugin/MiniWidgets.php
+++ b/Plugin/MiniWidgets.php
@@ -103,7 +103,7 @@ class MiniWidgets
         $store = $this->storeManager->getStore();
         $product = $subject->getPrice()->getProduct();
 
-        $amount = (int)round($subject->getPrice()->getValue() * 100);
+        $amount = (int)round($subject->getPrice()->getAmount()->getValue() * 100);
         $result .= StoreContext::doWithStore($store->getId(), function () use ($amount, $store, $product) {
             return $this->getHtml($amount, $store, $product);
         });

--- a/view/frontend/templates/scripts.phtml
+++ b/view/frontend/templates/scripts.phtml
@@ -31,7 +31,7 @@
                 let sequraElements = document.getElementsByClassName('sequra-promotion-widget');
 
                 [...sequraElements].forEach((el) => {
-                    el.setAttribute('data-amount', (Number(grandTotal.innerText.replace(/[^0-9\.-]+/g, "")) * 100));
+                    el.setAttribute('data-amount', Math.round(Number(grandTotal.innerText.replace(/[^0-9\.-]+/g, "")) * 100));
                 });
 
                 Sequra.refreshComponents?.();


### PR DESCRIPTION
 ### What is the goal?

Fix reported issue with widget amount when product price has more than 2 decimals.

 ### How is it being implemented?

When product price is converted to minor unit, it is multiplied by 100, rounded to 0 decimals and cast to integer.

### Does it affect (changes or update) any sensitive data?

No.

 ### How is it tested?

Manual tests.

In Magento 2 shop, enable taxes and set a Tax rule with a percentage that has several decimals. On storefront, check the widgets on product pages.

 ### How is it going to be deployed?

Standard deployment
