### PR TITLE
Add check if order has been paid using SeQura payment methods in observers

### DIFF
--- a/Observer/OrderAddressObserver.php
+++ b/Observer/OrderAddressObserver.php
@@ -14,6 +14,7 @@ use SeQura\Core\BusinessLogic\Domain\Order\Service\OrderService;
 use Sequra\Core\Controller\Webhook\Index as WebhookController;
 use SeQura\Core\Infrastructure\Logger\Logger;
 use SeQura\Core\Infrastructure\ServiceRegister;
+use Sequra\Core\Model\Ui\ConfigProvider;
 use Sequra\Core\Services\BusinessLogic\Utility\SeQuraTranslationProvider;
 use Sequra\Core\Services\BusinessLogic\Utility\TransformEntityService;
 
@@ -81,6 +82,11 @@ class OrderAddressObserver implements ObserverInterface
     private function handleAddressUpdate(MagentoAddress $magentoAddress): void
     {
         $magentoOrder = $magentoAddress->getOrder();
+
+        if ($magentoOrder->getPayment()->getMethod() !== ConfigProvider::CODE) {
+            return;
+        }
+
         if ($magentoOrder->getStatus() === Order::STATE_PAYMENT_REVIEW) {
             throw new LocalizedException($this->translationProvider->translate('sequra.error.cannotUpdate'));
         }

--- a/Observer/OrderCancellationObserver.php
+++ b/Observer/OrderCancellationObserver.php
@@ -15,6 +15,7 @@ use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderUpdateData;
 use SeQura\Core\BusinessLogic\Domain\Order\Service\OrderService;
 use SeQura\Core\Infrastructure\Logger\Logger;
 use SeQura\Core\Infrastructure\ServiceRegister;
+use Sequra\Core\Model\Ui\ConfigProvider;
 use Sequra\Core\Services\BusinessLogic\Utility\SeQuraTranslationProvider;
 
 /**
@@ -50,7 +51,8 @@ class OrderCancellationObserver implements ObserverInterface
     public function execute(Observer $observer): void
     {
         $orderData = $observer->getData('order');
-        if (WebhookController::isWebhookProcessing() || $orderData->getStatus() !== Order::STATE_CANCELED) {
+        if (WebhookController::isWebhookProcessing() || $orderData->getStatus() !== Order::STATE_CANCELED ||
+            $orderData->getPayment()->getMethod() !== ConfigProvider::CODE) {
             return;
         }
 

--- a/Observer/OrderShipmentObserver.php
+++ b/Observer/OrderShipmentObserver.php
@@ -13,6 +13,7 @@ use SeQura\Core\BusinessLogic\Domain\Order\Models\OrderUpdateData;
 use SeQura\Core\BusinessLogic\Domain\Order\Service\OrderService;
 use SeQura\Core\Infrastructure\Logger\Logger;
 use SeQura\Core\Infrastructure\ServiceRegister;
+use Sequra\Core\Model\Ui\ConfigProvider;
 use Sequra\Core\Services\BusinessLogic\Utility\SeQuraTranslationProvider;
 use Sequra\Core\Services\BusinessLogic\Utility\TransformEntityService;
 
@@ -76,6 +77,10 @@ class OrderShipmentObserver implements ObserverInterface
     private function handleShipment(MagentoShipment $shipmentData): void
     {
         $orderData = $shipmentData->getOrder();
+
+        if ($orderData->getPayment()->getMethod() !== ConfigProvider::CODE) {
+            return;
+        }
 
         if ($orderData->getStatus() === Order::STATE_PAYMENT_REVIEW) {
             throw new LocalizedException($this->translationProvider->translate('sequra.error.cannotShip'));


### PR DESCRIPTION
What is the goal?
Prevent observers from processing orders that have not been payed using SeQura payment methods.

How is it being implemented?
In observers, if payment method is not SeQura payment method - return.

Does it affect (changes or update) any sensitive data?
No.

How is it tested?
Manual tests.
Install Magento 2 shop and create an order using any of the Magento's native payment methods. In the shop backoffice, go to order page and test changing address, shipping or cancelling an order.

How is it going to be deployed?
Standard deployment.