### PR TITLE
Remove reference to Magento PageBuilder interface

### DIFF
--- a/Model/Config/ContentType/AdditionalData/Provider/WidgetConfig.php
+++ b/Model/Config/ContentType/AdditionalData/Provider/WidgetConfig.php
@@ -4,7 +4,6 @@ namespace Sequra\Core\Model\Config\ContentType\AdditionalData\Provider;
 
 use Exception;
 use Magento\Framework\Data\Form\FormKey;
-use Magento\PageBuilder\Model\Config\ContentType\AdditionalData\ProviderInterface;
 use Sequra\Core\Helper\UrlHelper;
 
 /**
@@ -12,7 +11,7 @@ use Sequra\Core\Helper\UrlHelper;
  *
  * @package Sequra\Core\Model\Config\ContentType\AdditionalData\Provider
  */
-class WidgetConfig implements ProviderInterface
+class WidgetConfig
 {
     /**
      * @var UrlHelper


### PR DESCRIPTION
### Description

This fixes a bug whereby Magento setup:di:compile command doesn't work if this module is enabled and the Magento PageBuilder module is not available on the system.

The PageBuilder module might not be available on some versions of the community edition of Magento.

## How is it being implemented?

Just removing the Magento\PageBuilder\Model\Config\ContentType\AdditionalData\ProviderInterface reference in the \Sequra\Core\Model\Config\ContentType\AdditionalData\Provider\WidgetConfig class