### PR TITLE
Add dependency to PageBuilder

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -14,6 +14,7 @@
             <module name="Magento_Quote"/>
             <module name="Magento_Payment"/>
             <module name="Magento_Checkout"/>
+            <module name="Magento_PageBuilder"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
 ### What is the goal?

We have reviewed the [PR](https://github.com/sequra/magento2-core/pull/21) and came to the conclusion that it **is not safe** to merge it.
The dependency to the ProviderInterface is necessary for the WidgetConfig class in order for widget preview to work. If we remove the dependency, widgets preview will not work in Magento’s backoffice, therefore the merchants that want to use widgets will not be able to configure them.

Instead, we have added the dependency to the Magento_PageBuilder to the module, because with the current implementation, this is correct.

However, this would prevent merchants that have Magento shop’s without page builder from installing the module and using the payment methods in checkout. We would need input from SeQura team how we should handle this issue. We could remove widgets implementation from the core module version and create a new module for widgets functionality. However, we would need to further analyze this, since it would be a big change, and that should be a change request.

 ### How is it being implemented?

Added dependency to Magento_PageBuilder in module.xml file.

### Does it affect (changes or update) any sensitive data?

No.

 ### How is it tested?

Manual test. Install module via composer.

 ### How is it going to be deployed?

Standard deployment.
