### PR TITLE
Add command to configure sequra from command line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 .github export-ignore
 docs export-ignore
 docker export-ignore
+bin export-ignore

--- a/Console/Configure.php
+++ b/Console/Configure.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Copyright © 2017 SeQura Engineering. All rights reserved.
+ */
+
+namespace Sequra\Core\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use SeQura\Core\BusinessLogic\Domain\Connection\Models\AuthorizationCredentials;
+use SeQura\Core\BusinessLogic\Domain\Connection\Models\ConnectionData;
+use SeQura\Core\BusinessLogic\Domain\Connection\Services\ConnectionService;
+use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\EmptyCountryConfigurationParameterException;
+use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Exceptions\InvalidCountryCodeForConfigurationException;
+use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfiguration;
+use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\SellingCountry;
+use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\CountryConfigurationService;
+use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\SellingCountriesService;
+use SeQura\Core\BusinessLogic\Domain\GeneralSettings\Models\GeneralSettings;
+use SeQura\Core\BusinessLogic\Domain\GeneralSettings\Services\GeneralSettingsService;
+use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\Models\WidgetSettings;
+use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\Services\WidgetSettingsService;
+use SeQura\Core\BusinessLogic\SeQuraAPI\BaseProxy;
+use SeQura\Core\Infrastructure\ServiceRegister;
+use Sequra\Core\Services\Bootstrap;
+
+/**
+ * Console command to trigger DR report
+ */
+class Configure extends Command
+{
+    /**
+     *  Command name
+     */
+    const NAME = 'sequra:configure';
+    /**
+     * Names of input arguments or options
+     */
+    const INPUT_KEY_MERCHANT_REF = 'merchant_ref';
+    /**
+     * Values of input arguments or options
+     */
+    const INPUT_KEY_USERNAME = 'username';
+    /**
+     * Values of input arguments or options
+     */
+    const INPUT_KEY_ASSETS_KEY = 'assets_key';
+    /**
+     * Values of input arguments or options
+     */
+    const INPUT_KEY_ENDPOINT = 'endpoint';
+    /**
+     * Values of input arguments or options
+     */
+    const INPUT_KEY_PASSWORD = 'password';
+
+    /**
+     * @var ConnectionService
+     */
+    private $connectionService;
+    /**
+     * @var GeneralSettingsService
+     */
+    private $generalSettingsService;
+    /**
+     * @var SellingCountriesService
+     */
+    private $sellingCountriesService;
+    /**
+     * @var CountryConfigurationService
+     */
+    private $countryConfigService;
+
+    /**
+     * @param Bootstrap $bootstrap
+     */
+    public function __construct(
+        Bootstrap                $bootstrap
+    )
+    {
+        parent::__construct();
+        $bootstrap->initInstance();
+    }
+    /**
+     * Initialize triggerreport command
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $inputOptions = [
+
+        ];
+        $this->setName(self::NAME)
+            ->setDescription('Quickly set sequra configuration')
+            ->addOption(
+                self::INPUT_KEY_MERCHANT_REF,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Merchant reference'
+            )
+            ->addOption(
+                self::INPUT_KEY_USERNAME,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Username'
+            )
+            ->addOption(
+                self::INPUT_KEY_ASSETS_KEY,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Assets key'
+            )
+            ->addOption(
+                self::INPUT_KEY_ENDPOINT,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Endpoint'
+            )
+            ->addOption(
+                self::INPUT_KEY_PASSWORD,
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Password'
+            );
+        parent::configure();
+    }
+
+    /**
+     * Execute command.
+     *
+     * @param InputInterface  $input  InputInterface
+     * @param OutputInterface $output OutputInterface
+     *
+     * @return                                        void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->saveConnectionData(
+            $input->getOption(self::INPUT_KEY_ENDPOINT),
+            $input->getOption(self::INPUT_KEY_USERNAME),
+            $input->getOption(self::INPUT_KEY_PASSWORD)
+        );
+        $this->saveCountriesConfig(
+            $this->getSellingCountriesService()->getSellingCountries(),
+            $input->getOption(self::INPUT_KEY_MERCHANT_REF)
+        );
+        $generalSettings = new GeneralSettings(
+            false,
+            true,
+            [],
+            [],
+            []
+        );
+        $this->getGeneralSettingsService()->saveGeneralSettings($generalSettings);
+        $this->saveWidgetSettings($input->getOption(self::INPUT_KEY_ASSETS_KEY));
+        return 0;
+    }
+
+        /**
+     * @param string $endpoint
+     * @param string $username
+     * @param string $password
+     *
+     * @return void
+     *
+     * @throws InvalidEnvironmentException
+     */
+    private function saveConnectionData(string $endpoint, string $username, string $password)
+    {
+        $connectionData = new ConnectionData(
+            $endpoint === 'https://sandbox.sequrapi.com/orders' ? BaseProxy::TEST_MODE : BaseProxy::LIVE_MODE,
+            '',
+            new AuthorizationCredentials($username, $password)
+        );
+        $this->getConnectionService()->saveConnectionData($connectionData);
+    }
+    /**
+     * @return ConnectionService
+     */
+    private function getConnectionService(): ConnectionService
+    {
+        if ($this->connectionService === null) {
+            $this->connectionService = ServiceRegister::getService(ConnectionService::class);
+        }
+
+        return $this->connectionService;
+    }
+    /**
+     * @return GeneralSettingsService
+     */
+    private function getGeneralSettingsService(): GeneralSettingsService
+    {
+        if ($this->generalSettingsService === null) {
+            $this->generalSettingsService = ServiceRegister::getService(GeneralSettingsService::class);
+        }
+
+        return $this->generalSettingsService;
+    }
+    /**
+     * @param SellingCountry[] $sellingCountries
+     * @param string $merchantId
+     *
+     * @return void
+     *
+     * @throws EmptyCountryConfigurationParameterException
+     * @throws InvalidCountryCodeForConfigurationException
+     */
+    private function saveCountriesConfig(array $sellingCountries, string $merchantId)
+    {
+        $countryConfiguration = [];
+        foreach ($sellingCountries as $country) {
+            $countryConfiguration[] = new CountryConfiguration($country->getCode(), $merchantId);
+        }
+
+        $this->getCountryConfigService()->saveCountryConfiguration($countryConfiguration);
+    }
+    /**
+     * @return CountryConfigurationService
+     */
+    private function getCountryConfigService(): CountryConfigurationService
+    {
+        if ($this->countryConfigService === null) {
+            $this->countryConfigService = ServiceRegister::getService(CountryConfigurationService::class);
+        }
+
+        return $this->countryConfigService;
+    }
+     /**
+     * @return SellingCountriesService
+     */
+    private function getSellingCountriesService(): SellingCountriesService
+    {
+        if ($this->sellingCountriesService === null) {
+            $this->sellingCountriesService = ServiceRegister::getService(SellingCountriesService::class);
+        }
+
+        return $this->sellingCountriesService;
+    }
+
+    /**
+     * @param string $assetsKey
+     *
+     * @return void
+     *
+     * @throws HttpRequestException
+     * @throws Exception
+     */
+    private function saveWidgetSettings(string $assetsKey)
+    {
+        if (!$this->getWidgetSettingsService()->isAssetsKeyValid($assetsKey)) {
+            return;
+        }
+
+        $widgetSettings = new WidgetSettings(false, $assetsKey);
+        $this->getWidgetSettingsService()->setWidgetSettings($widgetSettings);
+    }
+    /**
+     * @return WidgetSettingsService
+     */
+    private function getWidgetSettingsService(): WidgetSettingsService
+    {
+        return ServiceRegister::getService(WidgetSettingsService::class);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "pagos",
         "magento2"
     ],
-    "version": "2.5.0.4",
+    "version": "2.5.1",
     "license": "MIT",
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "02abb91b23c5de31dbfaeecaddf6aeb7",
+    "content-hash": "0831f83fa70e54df96f0bc90bbb725fe",
     "packages": [
         {
             "name": "sequra/integration-core",
@@ -250,22 +250,22 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.10",
+            "version": "1.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "51609a5b89f928e0c463d6df80eb38eff1eaf544"
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/51609a5b89f928e0c463d6df80eb38eff1eaf544",
-                "reference": "51609a5b89f928e0c463d6df80eb38eff1eaf544",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
@@ -334,20 +334,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-03-17T23:44:50+00:00"
+            "time": "2024-05-20T13:34:27+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.66",
+            "version": "1.11.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd"
+                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/94779c987e4ebd620025d9e5fdd23323903950bd",
-                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/52d2bbfdcae7f895915629e4694e9497d0f8e28d",
+                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d",
                 "shasum": ""
             },
             "require": {
@@ -390,13 +390,9 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-28T16:17:31+00:00"
+            "time": "2024-07-06T11:17:41+00:00"
         },
         {
             "name": "rector/rector",
@@ -456,16 +452,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.1",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909"
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/267a4405fff1d9c847134db3a3c92f1ab7f77909",
-                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/8f90f7a53ce271935282967f53d0894f8f1ff877",
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877",
                 "shasum": ""
             },
             "require": {
@@ -532,20 +528,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-03-31T21:03:09+00:00"
+            "time": "2024-05-22T21:24:41+00:00"
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.11.1",
+            "version": "v15.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "ab4ff2719b101dc3bfc3aaaf800edc21a98c56dc"
+                "reference": "7bcd31d1dcf67781ed5cb493b22c519c539c05e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/ab4ff2719b101dc3bfc3aaaf800edc21a98c56dc",
-                "reference": "ab4ff2719b101dc3bfc3aaaf800edc21a98c56dc",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/7bcd31d1dcf67781ed5cb493b22c519c539c05e6",
+                "reference": "7bcd31d1dcf67781ed5cb493b22c519c539c05e6",
                 "shasum": ""
             },
             "require": {
@@ -558,15 +554,15 @@
                 "amphp/http-server": "^2.1",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.51.0",
+                "friendsofphp/php-cs-fixer": "3.59.3",
                 "mll-lab/php-cs-fixer-config": "^5",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "1.10.59",
-                "phpstan/phpstan-phpunit": "1.3.16",
-                "phpstan/phpstan-strict-rules": "1.5.2",
-                "phpunit/phpunit": "^9.5 || ^10",
+                "phpstan/phpstan": "1.11.5",
+                "phpstan/phpstan-phpunit": "1.4.0",
+                "phpstan/phpstan-strict-rules": "1.6.0",
+                "phpunit/phpunit": "^9.5 || ^10.5.21",
                 "psr/http-message": "^1 || ^2",
                 "react/http": "^1.6",
                 "react/promise": "^2.0 || ^3.0",
@@ -598,7 +594,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.11.1"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.12.5"
             },
             "funding": [
                 {
@@ -606,14 +602,12 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-03-11T10:21:05+00:00"
+            "time": "2024-06-23T11:30:58+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "sequra/integration-core": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -621,5 +615,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -143,6 +143,15 @@
         </arguments>
     </type>
 
+    <!-- Commandline option to triggerrerport and update orders-->
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                 <item name="Configure" xsi:type="object">Sequra\Core\Console\Configure</item>
+            </argument>
+        </arguments>
+     </type>
+
     <!-- CSRF -->
     <type name="Magento\Framework\App\Request\CsrfValidator">
         <plugin name="sequra_disable_form_key_validation" type="Sequra\Core\Plugin\Framework\App\Request\CsrfValidator" />

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sequra_Core" setup_version="2.5.0.4">
+    <module name="Sequra_Core" setup_version="2.5.1">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
 ### What is the goal?

Have a way to setup seQura minimun configuration using CLI 

 ### How is it being implemented?

Created a Symfony Console command

```bash
bin/magento sequra:configure --merchant_ref="${SQ_MERCHANT_REF}" \
    --username="${SQ_USER_NAME}" \
    --assets_key="${SQ_ASSETS_KEY}" \
    --endpoint="${SQ_ENDPOINT}" \
    --password="${SQ_USER_SECRET}"
```

 ### Opportunistic refactorings

Changed version number to X.Y.Z format required by Adobe App Store

 ### Caveats

### Does it affect (changes or update) any sensitive data?
No

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?
Standard deployment