### PR TITLE
Fix settings breaks when no payment method is defined

### DIFF
--- a/view/adminhtml/web/js/PaymentController.js
+++ b/view/adminhtml/web/js/PaymentController.js
@@ -177,6 +177,9 @@ if (!window.SequraFE) {
          * @returns {TableCell[][]}
          */
         const getTableRows = () => {
+            if (!paymentMethods) {
+                return [];
+            }
             return paymentMethods.map((method) => {
                 return [
                     {


### PR DESCRIPTION
 ### What is the goal?

Fix settings breaks when no payment method is defined

 ### References
* **Issue:** [PAR-431](https://sequra.atlassian.net/jira/software/projects/PAR/boards/153?selectedIssue=PAR-431)

 ### How is it being implemented?

Validate that the payment methods array is not null before calling the map method

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

Standard deployment


[PAR-431]: https://sequra.atlassian.net/browse/PAR-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ