### PR TITLE
Enable csp report_only mode to not block inline script in the sequra …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "pagos",
         "magento2"
     ],
-    "version": "2.5.1",
+    "version": "2.5.2",
     "license": "MIT",
     "authors": [
         {

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
+        <csp>
+            <mode>
+                <storefront>
+                    <report_only>1</report_only>
+                </storefront>
+            </mode>
+        </csp>
         <payment>
             <sequra_payment>
                 <debug>1</debug>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,34 +3,34 @@
     <policies>
         <policy id="img-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
         <policy id="script-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
         <policy id="frame-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
     </policies>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sequra_Core" setup_version="2.5.1">
+    <module name="Sequra_Core" setup_version="2.5.2">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
 ### What is the goal?

Have the checkout working agin with the new Content Secutiry Policies at MAgento 2.4.7

> In Adobe Commerce and Magento Open Source version 2.4.7 and later, CSP is configured in restrict-mode by default for payment pages in the storefront and admin areas, and in report-only mode for all other pages. 

 ### References
* **Issue:** _jira issue goes here, if suggesting a new feature or change, please discuss it in an issue first_
* **Related pull-requests:** _list of related pull-requests (comma-separated): #1, #2_
* **Sentry errors:** _list of links to Sentry errors (comma-separated): link1, link2_
* **Any other references (AppSignal, Prometheus, ...):** _list of links to other references (comma-separated): link1, link2_

 ### How is it being implemented?

We have enabled the report_only mode for our plugin

Our checkout form needs an inline script that changes and is generated outside Magento so that we can't generate a hash to add it to the csp_whitelist or use a nonce provider.

 ### Opportunistic refactorings
Version bump
 
### Caveats


### Does it affect (changes or update) any sensitive data?

 ### How is it tested?

Manual tests