### PR TITLE
Fix/order link to back office

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "pagos",
         "magento2"
     ],
-    "version": "2.5.1",
+    "version": "2.5.2",
     "license": "MIT",
     "authors": [
         {

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
+        <csp>
+            <mode>
+                <storefront>
+                    <report_only>1</report_only>
+                </storefront>
+            </mode>
+        </csp>
         <payment>
             <sequra_payment>
                 <debug>1</debug>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,34 +3,34 @@
     <policies>
         <policy id="img-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
         <policy id="script-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
         <policy id="frame-src">
             <values>
-                <value id="sequra-sandbox-cdn" type="host">https://sandbox.sequracdn.com</value>
-                <value id="sequra-production-cdn" type="host">https://live.sequracdn.com</value>
-                <value id="sequra-sandbox-api" type="host">https://sandbox.sequrapi.com</value>
-                <value id="sequra-production-api" type="host">https://live.sequrapi.com</value>
+                <value id="sequra-sandbox-cdn" type="host">sandbox.sequracdn.com</value>
+                <value id="sequra-production-cdn" type="host">live.sequracdn.com</value>
+                <value id="sequra-sandbox-api" type="host">sandbox.sequrapi.com</value>
+                <value id="sequra-production-api" type="host">live.sequrapi.com</value>
             </values>
         </policy>
     </policies>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sequra_Core" setup_version="2.5.1">
+    <module name="Sequra_Core" setup_version="2.5.2">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
 ### What is the goal?

Fix the link to order in seQura's back-office present in the Magento order listing in the back-office.

I was correct when the enviroment configured was `sandbox` but not when it was `live`

 ### References

 ### How is it being implemented?

Add one more constant for the base url for the live environment. Use one or other depending on the configuration value. 

 ### Opportunistic refactorings


 ### Caveats


### Does it affect (changes or update) any sensitive data?

No

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

Standard deployment"