### PR TITLE
Be more specific on the controller to override

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,9 +4,9 @@
     <default>
         <csp>
             <mode>
-                <storefront>
+                <storefront_checkout_index_index>
                     <report_only>1</report_only>
-                </storefront>
+                </storefront_checkout_index_index>
             </mode>
         </csp>
         <payment>


### PR DESCRIPTION
 ### What is the goal?

From Magento 2.4.7 version on the CSP policy is set as restrict mode for the checkout in the store front that blocks inline javascript.

We need to restore the report mode so that our checkout form works

 ### References
* **Issue:**  [TIJ-111](https://sequra.atlassian.net/browse/TIJ-111)

 ### How is it being implemented?


 ### Opportunistic refactorings

 ### Caveats

### Does it affect (changes or update) any sensitive data?

No

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

sd

[TIJ-111]: https://sequra.atlassian.net/browse/TIJ-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ