### PR TITLE
Fix the issue with wrong URL for live environment

### DIFF
--- a/Observer/OrderCancellationObserver.php
+++ b/Observer/OrderCancellationObserver.php
@@ -31,11 +31,6 @@ class OrderCancellationObserver implements ObserverInterface
     private $translationProvider;
 
     /**
-     * @var OrderService
-     */
-    private $orderService;
-
-    /**
      * @param SeQuraTranslationProvider $translationProvider
      */
     public function __construct(SeQuraTranslationProvider $translationProvider)
@@ -79,7 +74,11 @@ class OrderCancellationObserver implements ObserverInterface
             throw new LocalizedException($this->translationProvider->translate('sequra.error.cannotCancel'));
         }
 
-        StoreContext::doWithStore($orderData->getStoreId(), [$this->getOrderService(), 'updateOrder'], [
+        $orderService = StoreContext::doWithStore($orderData->getStoreId(), function () {
+            return ServiceRegister::getService(OrderService::class);
+        });
+
+        StoreContext::doWithStore($orderData->getStoreId(), [$orderService, 'updateOrder'], [
             new OrderUpdateData(
                 $orderData->getIncrementId(),
                 new SeQuraCart($orderData->getOrderCurrencyCode()),
@@ -87,20 +86,6 @@ class OrderCancellationObserver implements ObserverInterface
                 null, null
             )
         ]);
-    }
-
-    /**
-     * Returns an instance of Order service.
-     *
-     * @return OrderService
-     */
-    private function getOrderService(): OrderService
-    {
-        if (!isset($this->orderService)) {
-            $this->orderService = ServiceRegister::getService(OrderService::class);
-        }
-
-        return $this->orderService;
     }
 
     /**

--- a/Observer/OrderShipmentObserver.php
+++ b/Observer/OrderShipmentObserver.php
@@ -35,11 +35,6 @@ class OrderShipmentObserver implements ObserverInterface
     private $transformService;
 
     /**
-     * @var OrderService
-     */
-    private $orderService;
-
-    /**
      * @param SeQuraTranslationProvider $translationProvider
      * @param TransformEntityService $transformService
      */
@@ -89,7 +84,11 @@ class OrderShipmentObserver implements ObserverInterface
         $unshippedCart = $this->transformService->transformOrderCartToSeQuraCart($orderData, false);
         $shippedCart = $this->transformService->transformOrderCartToSeQuraCart($orderData, true);
 
-        StoreContext::doWithStore($orderData->getStoreId(), [$this->getOrderService(), 'updateOrder'], [
+        $orderService = StoreContext::doWithStore($orderData->getStoreId(), function () {
+            return ServiceRegister::getService(OrderService::class);
+        });
+
+        StoreContext::doWithStore($orderData->getStoreId(), [$orderService, 'updateOrder'], [
             new OrderUpdateData(
                 $orderData->getIncrementId(),
                 $shippedCart,
@@ -98,20 +97,6 @@ class OrderShipmentObserver implements ObserverInterface
                 null
             )
         ]);
-    }
-
-    /**
-     * Returns an instance of Order service.
-     *
-     * @return OrderService
-     */
-    private function getOrderService(): OrderService
-    {
-        if (!isset($this->orderService)) {
-            $this->orderService = ServiceRegister::getService(OrderService::class);
-        }
-
-        return $this->orderService;
     }
 
     /**


### PR DESCRIPTION
 ### What is the goal?

Fixed issue for live environment, when order is shipped, cancelled or updated, wrong SeQura API url was used.

 ### References

[LIS-45](https://sequra.atlassian.net/browse/LIS-45)

 ### How is it being implemented?

The OrderService was retrieved without context. This is now fixed.

### Does it affect (changes or update) any sensitive data?

No.

 ### How is it tested?

Manual tests.

 ### How is it going to be deployed?

Standard deployment.


[LIS-45]: https://sequra.atlassian.net/browse/LIS-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ