### PR TITLE
Set home delivery to false if shippingMethods is instore pickup

### DIFF
--- a/Model/Api/Builders/CreateOrderRequestBuilder.php
+++ b/Model/Api/Builders/CreateOrderRequestBuilder.php
@@ -191,22 +191,48 @@ class CreateOrderRequestBuilder implements \SeQura\Core\BusinessLogic\Domain\Ord
 
     private function generateCreateOrderRequest(): CreateOrderRequest
     {
+        //@var string
+        $shippingMethod = $this->quote->getShippingAddress()->getShippingMethod();
         return CreateOrderRequest::fromArray([
             'state' => '',
             'merchant' => $this->getMerchantData(),
-//            'merchant_reference' => [
-//                'order_ref_1' => $request->getOrder()->getId(),
-//            ],
             'cart' => $this->getCart(),
             'delivery_method' => [
-                'name' => $this->quote->getShippingAddress()->getShippingMethod(),
+                'name' => $shippingMethod,
+                'home_delivery' => !in_array(
+                    $shippingMethod,
+                    [
+                        //Magento MSI In-Store Pickup (BOPIS)
+                        'msi_instore_pickup',
+                        'instore_pickup',
+                        //Amasty Store Pickup
+                        'amstorepickup_amstorepickup',
+                        'amstorepickup_storepickup',
+                        //Mageplaza Store Pickup
+                        'mageplaza_storepickup',
+                        //Mirasvit Store Pickup
+                        'mirasvit_pickup',
+                        'mirasvit_storepickup',
+                        //MageWorx Store Pickup
+                        'mageworx_storepickup',
+                        'mageworx_instore_pickup',
+                        //Webkul Store Pickup
+                        'webkul_storepickup',
+                        //Other/Generic or Custom Store Pickup
+                        'storepickup_storepickup',
+                        'pickup_storepickup',
+                        'clickandcollect_clickandcollect',
+                        'instorepickup_instorepickup',
+                        'pickup_pickup',
+                        'clickandcollect',
+                        'pick_instore',
+                        'pickup',
+                    ]
+                ),
             ],
             'delivery_address' => $this->getAddress($this->quote->getShippingAddress()),
             'invoice_address' => $this->getAddress($this->quote->getBillingAddress()),
             'customer' => $this->getCustomer(),
-//            'instore' => [
-//                'code' => $request->getOrder()->getId(),
-//            ],
             'gui' => [
                 'layout' => 'desktop',
             ],

--- a/bin/n98-magerun2
+++ b/bin/n98-magerun2
@@ -1,4 +1,4 @@
 #!/bin/bash
 docker compose exec -u daemon -w /bitnami/magento magento bash -c \
-"[ ! -f 'vendor/bin/n98-magerun2' ] && vendor/bin/composer require n98/magerun2-dist"
+"[ ! -f 'vendor/bin/n98-magerun2' ] && php vendor/bin/composer require n98/magerun2-dist"
 docker compose exec -u daemon -w /bitnami/magento magento vendor/bin/n98-magerun2 $@

--- a/bin/update-sources
+++ b/bin/update-sources
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker cp ${COMPOSE_PROJECT_NAME:-sequra}-magento:/var/www/html .magento-src
+docker cp ${COMPOSE_PROJECT_NAME:-magento2-core}-magento:/bitnami/magento .magento-src


### PR DESCRIPTION
 ### What is the goal?

Identify shipping methods that imply not delivering to shopper home address.

 ### References
* **Issue:** PAR-483

 ### How is it being implemented?

Got a list of plugins for store pickup and similar shipping methods and added the list of their shipping method code to compare with.

 ### Opportunistic refactorings

Fixes in the scripts used for testing.

 ### Caveats

There may be other shipping method that are not included because
### Does it affect (changes or update) any sensitive data?

No

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

 "Standard deployment"
