### PR TITLE
Add min and max allowed amount validation per payment method for widgets

### DIFF
--- a/Block/Widget/Teaser.php
+++ b/Block/Widget/Teaser.php
@@ -14,6 +14,8 @@ use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\Models\WidgetSettings;
 use SeQura\Core\BusinessLogic\Domain\PromotionalWidgets\Services\WidgetSettingsService;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Models\CountryConfiguration;
 use SeQura\Core\BusinessLogic\Domain\CountryConfiguration\Services\CountryConfigurationService;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\Services\PaymentMethodsService;
+use SeQura\Core\BusinessLogic\Domain\PaymentMethod\Models\SeQuraPaymentMethod;
 
 class Teaser extends Template implements BlockInterface
 {
@@ -274,23 +276,54 @@ class Teaser extends Template implements BlockInterface
         }
 
         $currentCountry = $this->getCurrentCountry();
+        $paymentMethods = $this->getPaymentMethods($merchantId);
+        $priceSelector = addslashes($this->getData('price_sel') ?: '');
+        $theme = $this->getData('theme') ?: $this->getWidgetSettings()->getWidgetConfig();
+        $destinationSelector = addslashes($this->getData('dest_sel') ?: '');
+
         $widgets = [];
-        foreach($this->getPaymentMethodsData() as $payment_method){
-            if(!isset($payment_method['countryCode'], $payment_method['product']) || $payment_method['countryCode'] !== $currentCountry){
+        foreach($this->getPaymentMethodsData() as $paymentMethodData){
+            if(!isset($paymentMethodData['countryCode'], $paymentMethodData['product']) || $paymentMethodData['countryCode'] !== $currentCountry){
                 continue;
             }
 
-            $widgets[] = [
-                'product' => $payment_method['product'],
-                'campaign' => $payment_method['campaign'] ?? '',
-                'priceSel' => addslashes(($this->getData('price_sel') ?: '')),
-                'dest' => addslashes(($this->getData('dest_sel') ?: '')),
-                'theme' => $this->getData('theme') ?: $this->getWidgetSettings()->getWidgetConfig(),
-                'reverse' => "0",
-                'minAmount' => $payment_method['minAmount'] ?? 0,
-                'maxAmount' => $payment_method['maxAmount'] ?? null,
-            ];
+            foreach ($paymentMethods as $paymentMethod) {
+                if($paymentMethod->getProduct() !== $paymentMethodData['product'] || $paymentMethod->getCampaign() !== $paymentMethodData['campaign']){
+                    continue;
+                }
+
+                $widgets[] = [
+                    'product' => $paymentMethod->getProduct(),
+                    'campaign' => $paymentMethod->getCampaign() ?? '',
+                    'priceSel' => $priceSelector,
+                    'dest' => $destinationSelector,
+                    'theme' => $theme,
+                    'reverse' => "0",
+                    'minAmount' => $paymentMethod->getMinAmount() ?? 0,
+                    'maxAmount' => $paymentMethod->getMaxAmount() ?? null,
+                ];
+
+                break;
+            }   
         }
         return $widgets;
+    }
+
+    /**
+     * Get payment methods for a given merchant using the current store context
+     * @param string $merchantId
+     * @return SeQuraPaymentMethod[]
+     */
+    private function getPaymentMethods($merchantId){
+        $storeId = $this->scopeResolver->getScope()->getStoreId();
+        $payment_methods = [];
+        try {
+            $payment_methods = StoreContext::doWithStore($storeId, function () use ( $merchantId ) {
+                return ServiceRegister::getService(PaymentMethodsService::class)->getMerchantsPaymentMethods($merchantId);
+            });
+        } catch ( \Throwable $e ) {
+            // TODO: Log error
+        }
+        return $payment_methods;
     }
 }

--- a/Block/Widget/Teaser.php
+++ b/Block/Widget/Teaser.php
@@ -287,6 +287,8 @@ class Teaser extends Template implements BlockInterface
                 'dest' => addslashes(($this->getData('dest_sel') ?: '')),
                 'theme' => $this->getData('theme') ?: $this->getWidgetSettings()->getWidgetConfig(),
                 'reverse' => "0",
+                'minAmount' => $payment_method['minAmount'] ?? 0,
+                'maxAmount' => $payment_method['maxAmount'] ?? null,
             ];
         }
         return $widgets;

--- a/Model/Config/Source/WidgetPaymentMethods.php
+++ b/Model/Config/Source/WidgetPaymentMethods.php
@@ -52,9 +52,7 @@ class WidgetPaymentMethods implements OptionSourceInterface
                 $value = [
                     'countryCode' => $country->getCountryCode(),
                     'product' => $payment_method->getProduct(),
-                    'campaign' => $payment_method->getCampaign(),
-                    'minAmount' => $payment_method->getMinAmount(),
-                    'maxAmount' => $payment_method->getMaxAmount() 
+                    'campaign' => $payment_method->getCampaign()
                 ];
                 $value = base64_encode(json_encode($value));
 

--- a/Model/Config/Source/WidgetPaymentMethods.php
+++ b/Model/Config/Source/WidgetPaymentMethods.php
@@ -52,7 +52,9 @@ class WidgetPaymentMethods implements OptionSourceInterface
                 $value = [
                     'countryCode' => $country->getCountryCode(),
                     'product' => $payment_method->getProduct(),
-                    'campaign' => $payment_method->getCampaign() 
+                    'campaign' => $payment_method->getCampaign(),
+                    'minAmount' => $payment_method->getMinAmount(),
+                    'maxAmount' => $payment_method->getMaxAmount() 
                 ];
                 $value = base64_encode(json_encode($value));
 

--- a/view/frontend/web/js/widget-initializer.js
+++ b/view/frontend/web/js/widget-initializer.js
@@ -327,6 +327,10 @@ define([
         
                             oldWidget.remove();// remove the old widget to draw a new one.
                         }
+
+                        if ('undefined' !== typeof widget.maxAmount && widget.maxAmount && widget.maxAmount < cents) {
+                            return;
+                        }
         
                         const promoWidgetNode = document.createElement('div');
                         promoWidgetNode.className = className + ' ' + modifierClassName;

--- a/view/frontend/web/js/widget-initializer.js
+++ b/view/frontend/web/js/widget-initializer.js
@@ -245,6 +245,15 @@ define([
                     isMiniWidget: function (widget) {
                         return this.miniWidgets.indexOf(widget) !== -1;
                     },
+                    isAmountInAllowedRange: function (widget, cents) {
+                        if ('undefined' !== typeof widget.minAmount && widget.minAmount && cents < widget.minAmount) {
+                            return false;
+                        }
+                        if ('undefined' !== typeof widget.maxAmount && widget.maxAmount && widget.maxAmount < cents) {
+                            return false;
+                        }
+                        return true;
+                    },
         
                     drawMiniWidgetOnElement: function (widget, element, priceElem) {
                         if (!priceElem) {
@@ -256,9 +265,6 @@ define([
                             }
                         }
                         const cents = this.nodeToCents(priceElem);
-        
-        
-        
                         const className = 'sequra-educational-popup';
                         const modifierClassName = className + '--' + widget.product;
         
@@ -271,7 +277,7 @@ define([
                             oldWidget.remove();// remove the old widget to draw a new one.
                         }
         
-                        if (widget.maxAmount && widget.maxAmount < cents) {
+                        if (!this.isAmountInAllowedRange(widget, cents)) {
                             return;
                         }
         
@@ -315,7 +321,6 @@ define([
                             return;
                         }
                         const cents = this.nodeToCents(priceElem);
-        
                         const className = 'sequra-promotion-widget';
                         const modifierClassName = className + '--' + widget.product;
         
@@ -328,7 +333,7 @@ define([
                             oldWidget.remove();// remove the old widget to draw a new one.
                         }
 
-                        if ('undefined' !== typeof widget.maxAmount && widget.maxAmount && widget.maxAmount < cents) {
+                        if (!this.isAmountInAllowedRange(widget, cents)) {
                             return;
                         }
         

--- a/view/frontend/web/js/widget.js
+++ b/view/frontend/web/js/widget.js
@@ -20,7 +20,9 @@ define([
                     priceSel: widget.priceSel,
                     dest: widget.dest || '#' + config.divId,
                     theme: widget.theme,
-                    reverse: widget.reverse
+                    reverse: widget.reverse,
+                    minAmount: widget.minAmount,
+                    maxAmount: widget.maxAmount
                 });
             }
         }


### PR DESCRIPTION
 ### What is the goal?

Show or hide widgets on product page based on the seQura product's amount in cents limits.

 ### References
* **Issue:** PAR-521

 ### How is it being implemented?

This pull request introduces several changes to the `Block/Widget/Teaser.php` file and related JavaScript files to enhance the handling of payment methods and widget initialization. The most important changes include adding new services and models, updating widget configuration logic, and improving the validation of widget amounts.

Enhancements to handling payment methods:

* [`Block/Widget/Teaser.php`](diffhunk://#diff-3178001cd876f098bf439edc0129bdbd3b9cdfe2ba76802aea523d47a9784c82R17-R18): Added `PaymentMethodsService` and `SeQuraPaymentMethod` to the list of used services and models.
* [`Block/Widget/Teaser.php`](diffhunk://#diff-3178001cd876f098bf439edc0129bdbd3b9cdfe2ba76802aea523d47a9784c82R279-R328): Updated the `getAvailableWidgets` method to include new logic for retrieving and validating payment methods, and added a new private method `getPaymentMethods` to fetch payment methods for a given merchant.

Improvements to widget initialization:

* [`view/frontend/web/js/widget-initializer.js`](diffhunk://#diff-6468b5ce066566b30ec0d66ba18437b375dd3dc03288fb53fb1c77faea3f4f1eR248-R256): Added `isAmountInAllowedRange` method to validate if the widget amount is within the allowed range.
* [`view/frontend/web/js/widget-initializer.js`](diffhunk://#diff-6468b5ce066566b30ec0d66ba18437b375dd3dc03288fb53fb1c77faea3f4f1eL274-R280): Updated the widget drawing logic to use the new `isAmountInAllowedRange` method for validation. [[1]](diffhunk://#diff-6468b5ce066566b30ec0d66ba18437b375dd3dc03288fb53fb1c77faea3f4f1eL274-R280) [[2]](diffhunk://#diff-6468b5ce066566b30ec0d66ba18437b375dd3dc03288fb53fb1c77faea3f4f1eR336-R339)

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

Standard deployment