### PR TITLE
Fix widget display on payment method selection

### DIFF
--- a/Block/Widget/Teaser.php
+++ b/Block/Widget/Teaser.php
@@ -245,7 +245,7 @@ class Teaser extends Template implements BlockInterface
         return strtoupper(count($parts) > 1 ? $parts[1] : $parts[0]);
     }
 
-    private function getMerchantRef()
+    private function getMerchantId()
     {
         $country = $this->getCurrentCountry();
         $settingsArr = $this->getCountrySettings();
@@ -270,7 +270,7 @@ class Teaser extends Template implements BlockInterface
      * @return array
      */
     public function getAvailableWidgets(){
-        $merchantId = $this->getMerchantRef();
+        $merchantId = $this->getMerchantId();
         if(!$merchantId ){
             return [];
         }

--- a/Block/WidgetInitializer.php
+++ b/Block/WidgetInitializer.php
@@ -241,22 +241,21 @@ class WidgetInitializer extends Template
 
     public function getMerchantRef()
     {
-        $country = $this->getCurrentCountry();
         $settingsArr = $this->getCountrySettings();
-        if (is_array($settingsArr)) {
+        $quote = $this->session->getQuote();
+        $billingAddress = $quote->getBillingAddress();
+        $isBillingAddressExists = $billingAddress && $billingAddress->getId();
+        if (is_array($settingsArr) && $isBillingAddressExists) {
             foreach ($settingsArr as $settings) {
-                if ($settings->getCountryCode() === $country) {
+                if ($settings->getCountryCode() === $billingAddress->getCountry()) {
                     return $settings->getMerchantId();
                 }
             }
         }
-
-        $quote = $this->session->getQuote();
-        $billingAddress = $quote->getBillingAddress();
-
-        if (is_array($settingsArr) && $billingAddress) {
+        $country = $this->getCurrentCountry();
+        if (is_array($settingsArr)) {
             foreach ($settingsArr as $settings) {
-                if ($settings->getCountryCode() === $billingAddress->getCountry()) {
+                if ($settings->getCountryCode() === $country) {
                     return $settings->getMerchantId();
                 }
             }

--- a/view/frontend/templates/widget_initializer.phtml
+++ b/view/frontend/templates/widget_initializer.phtml
@@ -9,7 +9,7 @@
                 "thousandSeparator": "<?php echo $block->getThousandsSeparator(); ?>",
                 "decimalSeparator": "<?php echo $block->getDecimalSeparator(); ?>",
                 "locale": "<?php echo $block->getLocale(); ?>",
-                "merchant": "<?php echo $block->getMerchantRef(); ?>",
+                "merchant": "<?php echo $block->getMerchantId(); ?>",
                 "assetKey": "<?php echo $block->getAssetsKey(); ?>",
                 "products": <?php echo json_encode($block->getProducts()); ?>
             }


### PR DESCRIPTION
 ### What is the goal?

Fix fatal error on the payment method selection to fetch merchant ID base on Billing address.

 ### References
* **Issue:** [LIS-56](https://sequra.atlassian.net/browse/LIS-56)

 ### How is it being implemented?

The bug was in the Widget Initializer. Merchant id was fetched based on current locale on checkout. Now, if merchant ID is not found by locale, it is fetched by billing address country code.

 ### How is it tested?

* Manual tests  
  * Set up integration  
    - Enable SeQura widgets on the SeQura admin page.  
    - Configure SeQura widgets in the Magento 2 content settings.  
  * Go to the storefront payment selection and verify the widget display.  

 ### How is it going to be deployed?

Standard deployment


[LIS-56]: https://sequra.atlassian.net/browse/LIS-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ