### PR TITLE
Update packagist endpoint when fetching plugin version

### DIFF
--- a/Services/BusinessLogic/VersionService.php
+++ b/Services/BusinessLogic/VersionService.php
@@ -11,19 +11,19 @@ use SeQura\Core\BusinessLogic\Domain\Version\Models\Version;
 
 class VersionService implements VersionServiceInterface
 {
-    private const SEQURA_MAGENTO_REPOSITORY_URL = 'https://repo.packagist.org/p/sequra/magento2-core.json';
+    private const SEQURA_MAGENTO_REPOSITORY_URL = 'https://repo.packagist.org/p2/sequra/magento2-core.json';
     private const SEQURA_MAGENTO_DOWNLOAD_URL = 'https://github.com/sequra/magento2-core/releases';
 
     /**
      * @var ModuleList
      */
     private $moduleList;
-    
+
     /**
      * @var Client
      */
     private $client;
-    
+
     /**
      * @var Uri
      */
@@ -80,24 +80,26 @@ class VersionService implements VersionServiceInterface
         }
 
         $hubResponse = json_decode($hubResponse->getBody()->getContents(), true);
-        $latestVersionInfo = $this->getLatestVersionFromInfoResponse($hubResponse);
 
-        return $latestVersionInfo['version'] ?? null;
+        return $this->getLatestVersionFromInfoResponse($hubResponse);
     }
 
     /**
-     * Filters out non-version entities from the response.
+     * Filter latest tag version.
      *
      * @param array $response
      *
-     * @return array
+     * @return null|string
      */
-    private function getLatestVersionFromInfoResponse(array $response): array
+    private function getLatestVersionFromInfoResponse(array $response): ?string
     {
-        $filteredArray = array_filter($response['packages']['sequra/magento2-core'], static function ($key) {
-            return strpos($key, 'dev') !== 0;
-        }, ARRAY_FILTER_USE_KEY);
+        $filteredArray = array_map(
+            static function ($module) {
+                return $module['version'];
+            },
+            $response['packages']['sequra/magento2-core']
+        );
 
-        return end($filteredArray);
+        return reset($filteredArray) ?? null;
     }
 }


### PR DESCRIPTION
### What is the goal?
Fix the plugin version display on the SeQura admin page.

 ### References
- Issue: [LIS-59](https://sequra.atlassian.net/browse/LIS-59)

 ### How is it being implemented?
The code has been updated to use the new endpoint for fetching package data from Packagist, replacing the deprecated endpoint.
The  [Packagist](https://packagist.org/apidoc?type=concrete5-package#get-package-data) endpoint used by the integration to get the latest tag version is deprecated and no longer be updated as of February 1st, 2025. 
The integration now fetches the latest tag version using the new endpoint, with necessary adjustments made to handle the updated API response.

 ### How is it tested?
- Manual tests
  - Set up integration
  - Verify version display
 ### How is it going to be deployed?
Standard deployment