### PR TITLE
Add getCode callback to each Sequra payment method to resolve the reCaptcha binding error

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
@@ -98,8 +98,16 @@ define([
         loadSequraPaymentMethods: function (paymentMethodsResponse) {
             var self = this;
 
-            self.sequraPaymentMethods(paymentMethodsResponse);
-            sequraPaymentMethods(paymentMethodsResponse);
+            var enrichedPaymentMethods = paymentMethodsResponse.map(function (method) {
+                return Object.assign({}, method, {
+                    getCode: function () {
+                        return 'sequra_payment';
+                    }
+                });
+            });
+
+            self.sequraPaymentMethods(enrichedPaymentMethods);
+            sequraPaymentMethods(enrichedPaymentMethods);
 
             fullScreenLoader.stopLoader();
         },


### PR DESCRIPTION
### What is the goal?
Add missing getCode callback to each Sequra payment product to resolve the reCaptcha binding error.

 ### References
- Issue: [LIS-60](https://sequra.atlassian.net/browse/LIS-60)

 ### How is it being implemented?
The getCode callback was previously defined only at the level of the overall SeQura payment method, while each individual product (payment option) also required this callback for ReCaptcha to function properly.
Now, each SeQura product is enriched with its own getCode callback, resolving the ReCaptcha binding error.

 ### How is it tested?
- Manual tests
  - Set up integration.
  - Set up ReCaptcha Storefront.
  - Verify behavior during the checkout process, ensuring ReCaptcha is rendered and no binding errors occur.
 ### How is it going to be deployed?
Standard deployment

[LIS-60]: https://sequra.atlassian.net/browse/LIS-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ