### PR TITLE
Fix more info links at the checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
     },
     "node_modules/playwright-fixture-for-plugins": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#88eb10738a3ba07075a18cac4aa28aa030ed1e7b",
+      "resolved": "git+ssh://git@github.com/sequra/playwright-fixture-for-plugins.git#dbbc504d2393ea19a87c80f7c7fd8ff1ba21d753",
       "dev": true
     },
     "node_modules/undici-types": {

--- a/tests-e2e/fixtures/pages/CheckoutPage.js
+++ b/tests-e2e/fixtures/pages/CheckoutPage.js
@@ -27,8 +27,7 @@ export default class CheckoutPage extends BaseCheckoutPage {
             continueButton: () => this.page.locator('.action.continue'),
             submitCheckout: () => this.page.locator('.payment-method._active .action.checkout'),
             orderRowStatus: orderNumber => this.page.locator(`.data-row:has(td:has-text("${orderNumber}")) td:nth-child(9)`),
-            orderNumber: () => this.page.locator('.checkout-success p>span'),
-            paymentMethodEducationalLink: options => this.page.locator(`label[for="sequra_${options.product}"] .sequra-educational-popup`),
+            orderNumber: () => this.page.locator('.checkout-success p>span')
         };
     }
 
@@ -175,14 +174,14 @@ export default class CheckoutPage extends BaseCheckoutPage {
     }
 
     /**
-     * Find "+ info" link and click it
+     * Provide the locator for the moreInfo tag 
+     * 
      * @param {Object} options
      * @param {string} options.product seQura product (i1, pp3, etc)
-     * @returns {Promise<void>}
+     * @returns {import("@playwright/test").Locator}
      */
-    async openAndCloseEducationalPopup(options) {
-        await this.locators.paymentMethodEducationalLink(options).click();
-        await this.page.frameLocator('iframe').locator('button[data-testid="close-popup"]').click();
+    moreInfoLinkLocator(options) {
+        return this.page.locator(`label[for="sequra_${options.product}"] .sequra-educational-popup`)
     }
 
     /**

--- a/tests-e2e/fixtures/pages/CheckoutPage.js
+++ b/tests-e2e/fixtures/pages/CheckoutPage.js
@@ -28,6 +28,7 @@ export default class CheckoutPage extends BaseCheckoutPage {
             submitCheckout: () => this.page.locator('.payment-method._active .action.checkout'),
             orderRowStatus: orderNumber => this.page.locator(`.data-row:has(td:has-text("${orderNumber}")) td:nth-child(9)`),
             orderNumber: () => this.page.locator('.checkout-success p>span'),
+            paymentMethodEducationalLink: options => this.page.locator(`label[for="sequra_${options.product}"] .sequra-educational-popup`),
         };
     }
 
@@ -171,6 +172,17 @@ export default class CheckoutPage extends BaseCheckoutPage {
             default:
                 throw new Error(`Unknown product ${options.product}`);
         }
+    }
+
+    /**
+     * Find "+ info" link and click it
+     * @param {Object} options
+     * @param {string} options.product seQura product (i1, pp3, etc)
+     * @returns {Promise<void>}
+     */
+    async openAndCloseEducationalPopup(options) {
+        await this.locators.paymentMethodEducationalLink(options).click();
+        await this.page.frameLocator('iframe').locator('button[data-testid="close-popup"]').click();
     }
 
     /**

--- a/tests-e2e/specs/001-checkout-product.spec.js
+++ b/tests-e2e/specs/001-checkout-product.spec.js
@@ -28,7 +28,7 @@ test.describe('Product checkout', () => {
     await productPage.addToCart({ slug: 'push-it-messenger-bag', quantity: 1 });
     await checkoutPage.goto();
     await checkoutPage.fillForm(shopper);
-    await checkoutPage.openAndCloseEducationalPopup({ ...shopper, product: 'i1' });
+    await checkoutPage.openAndCloseEducationalPopup({ product: 'i1' });
     await checkoutPage.placeOrder({ ...shopper, product: 'i1' });
     await checkoutPage.waitForOrderSuccess();
   });

--- a/tests-e2e/specs/001-checkout-product.spec.js
+++ b/tests-e2e/specs/001-checkout-product.spec.js
@@ -28,6 +28,7 @@ test.describe('Product checkout', () => {
     await productPage.addToCart({ slug: 'push-it-messenger-bag', quantity: 1 });
     await checkoutPage.goto();
     await checkoutPage.fillForm(shopper);
+    await checkoutPage.openAndCloseEducationalPopup({ ...shopper, product: 'i1' });
     await checkoutPage.placeOrder({ ...shopper, product: 'i1' });
     await checkoutPage.waitForOrderSuccess();
   });

--- a/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
@@ -239,51 +239,5 @@ define([
         showLogo: function () {
             return window.checkoutConfig.payment.sequra_payment.showlogo;
         },
-
-        showWidgets: function () {
-            return window.checkoutConfig.payment.sequra_payment.showwidgets;
-        },
-
-        loadSeQuraScript: function () {
-            if (!window.checkoutConfig.payment.sequra_payment.widget_settings.hasOwnProperty('merchant')) {
-                return;
-            }
-
-            if (typeof Sequra === "undefined") {
-                let products = [];
-                window.checkoutConfig.payment.sequra_payment.widget_settings.products.forEach((product) => {
-                    products.push(product.id);
-                });
-                var sequraConfigParams = {
-                    merchant: window.checkoutConfig.payment.sequra_payment.widget_settings.merchant,
-                    assetKey: window.checkoutConfig.payment.sequra_payment.widget_settings.assetKey,
-                    products: products,
-                    scriptUri: window.checkoutConfig.payment.sequra_payment.widget_settings.scriptUri,
-                    decimalSeparator: window.checkoutConfig.payment.sequra_payment.widget_settings.decimalSeparator,
-                    thousandSeparator: window.checkoutConfig.payment.sequra_payment.widget_settings.thousandSeparator,
-                    locale: window.checkoutConfig.payment.sequra_payment.widget_settings.locale,
-                    currency: window.checkoutConfig.payment.sequra_payment.widget_settings.currency,
-                };
-
-                (
-                    function (i, s, o, g, r, a, m) {
-                        i["SequraConfiguration"] = g;
-                        i["SequraOnLoad"] = [];
-                        i[r] = {};
-                        i[r][a] = function (callback) {
-                            i["SequraOnLoad"].push(callback);
-                        };
-                        (a = s.createElement(o)),
-                            (m = s.getElementsByTagName(o)[0]);
-                        a.async = 1;
-                        a.src = g.scriptUri;
-                        m.parentNode.insertBefore(a, m);
-                    }
-                )
-                (window, document, "script", sequraConfigParams, "Sequra", "onLoad");
-            } else {
-                Sequra.refreshComponents?.();
-            }
-        }
     });
 });

--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -1,6 +1,6 @@
 <!-- ko foreach: sequraPaymentMethods -->
 <div class="payment-method" data-bind="css: {'_active': (product == $parent.getSelectedProduct())},
-                    afterRender: $parent.loadSeQuraScript">
+                    afterRender: Sequra.refreshComponents()">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"
@@ -15,7 +15,6 @@
             <span class="sequra_partpayment_cost_description" data-bind="text: cost_description"></span>
             <!--/ko-->
             &nbsp;
-            <!-- ko if: $parent.showWidgets() -->
             <span class="sequra-educational-popup" style="z-index: 1;"
                   data-bind="
                     attr: {
@@ -24,7 +23,6 @@
                         'data-campaign': campaign
                     }
                 "> + info</span>
-            <!-- /ko -->
         </label>
     </div>
 

--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -1,6 +1,6 @@
 <!-- ko foreach: sequraPaymentMethods -->
 <div class="payment-method" data-bind="css: {'_active': (product == $parent.getSelectedProduct())},
-                    afterRender: Sequra.refreshComponents()">
+                    afterRender: Sequra.refreshComponents">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"


### PR DESCRIPTION
 ### What is the goal?

seQura payment methods should show the "+ info" link in the checkout no matter if the widgets are set to be shown or not.

 ### References

 ### How is it being implemented?

This pull request simplifies the `sequra-payment.js` and `form.html` files by removing redundant logic and streamlining the integration of the SeQura payment system. The most significant changes involve the removal of the `loadSeQuraScript` method and its associated logic, as well as updates to the HTML template to reflect these changes.

### HTML Template Updates:
* Replaced the `afterRender` binding in `form.html` with a direct call to `Sequra.refreshComponents()` to handle SeQura component updates.
* Removed conditional logic for showing widgets (`showWidgets`) and its associated HTML elements, simplifying the template structure. [[1]](diffhunk://#diff-21862e0984127cb5fb117b163e93efb03c7720dcc8af2f041187de282e48fbabL18) [[2]](diffhunk://#diff-21862e0984127cb5fb117b163e93efb03c7720dcc8af2f041187de282e48fbabL27)

 ### Opportunistic refactorings

Remove dead code

* Removed the `loadSeQuraScript` method and its related logic from `sequra-payment.js`, including the dynamic script injection and configuration setup for SeQura widgets.

 ### Caveats

### Does it affect (changes or update) any sensitive data?
No
 ### How is it tested?

Automatic tests

 ### How is it going to be deployed?

Standard deployment
