### PR TITLE
Bugfix/par 547 fix performance issues in category validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ bin/php/*
 !bin/php/install
 !bin/php/composer.json
 !bin/php/README.md
+
+# MacOS
+.DS_Store
+
+*.gz

--- a/Gateway/Validator/ProductWidgetAvailabilityValidator.php
+++ b/Gateway/Validator/ProductWidgetAvailabilityValidator.php
@@ -103,14 +103,15 @@ class ProductWidgetAvailabilityValidator extends AbstractWidgetAvailabilityValid
             return false;
         }
 
-        $categoryIds = $product->getCategoryIds();
-        $trail = $this->productService->getAllProductCategories($categoryIds);
         $excludedProducts = $settings ? $settings->getExcludedProducts() : [];
         if (!is_array($excludedProducts)) {
             $excludedProducts = [];
         }
 
-        if (in_array($product->getData('sku'), $excludedProducts) || in_array($product->getSku(), $excludedProducts)) {
+        if (!empty($excludedProducts) &&
+            (in_array($product->getData('sku'), $excludedProducts)
+            || in_array($product->getSku(), $excludedProducts))
+            ) {
             return false;
         }
 
@@ -118,6 +119,12 @@ class ProductWidgetAvailabilityValidator extends AbstractWidgetAvailabilityValid
         if (!is_array($excludedCategories)) {
             $excludedCategories = [];
         }
+        if (empty($excludedCategories)) {
+            return true;
+        }
+
+        $categoryIds = $product->getCategoryIds();
+        $trail = $this->productService->getAllProductCategories($categoryIds);
 
         return empty(array_intersect($trail, $excludedCategories));
     }

--- a/Gateway/Validator/ProductWidgetAvailabilityValidator.php
+++ b/Gateway/Validator/ProductWidgetAvailabilityValidator.php
@@ -122,9 +122,8 @@ class ProductWidgetAvailabilityValidator extends AbstractWidgetAvailabilityValid
         if (empty($excludedCategories)) {
             return true;
         }
-
-        $categoryIds = $product->getCategoryIds();
-        $trail = $this->productService->getAllProductCategories($categoryIds);
+        
+        $trail = $this->productService->getAllProductCategoryIds($product->getCategoryIds());
 
         return empty(array_intersect($trail, $excludedCategories));
     }

--- a/Model/Api/Builders/CreateOrderRequestBuilder.php
+++ b/Model/Api/Builders/CreateOrderRequestBuilder.php
@@ -482,18 +482,24 @@ class CreateOrderRequestBuilder implements \SeQura\Core\BusinessLogic\Domain\Ord
             return $orders;
         }
 
+        /**
+         * @var Order $orderRow
+         */
         foreach ($orderCollection as $orderRow) {
             $order = [];
             $order['amount'] = $this->formatPrice(is_numeric($orderRow->getData('grand_total'))
                 ? (float) $orderRow->getData('grand_total') : 0);
             $order['currency'] = $orderRow->getData('order_currency_code');
-            $order['created_at'] = str_replace(' ', 'T', $orderRow->getData('created_at'));
+            $createdAt = $orderRow->getData('created_at');
+            $order['created_at'] = str_replace(' ', 'T', is_string($createdAt) ? $createdAt : '');
             $order['raw_status'] = $orderRow->getData('status');
-            $order['postal_code'] = $orderRow->getBillingAddress()->getPostCode();
-            $order['country_code'] = $orderRow->getBillingAddress()->getCountryId();
-            $order['status'] = $this->mapOrderStatus($orderRow->getData('status'));
-            $order['payment_method_raw'] = $orderRow->getPayment()->getAdditionalInformation()['method_title'] ?? '';
-            $order['payment_method'] = $this->mapPaymentName($orderRow->getPayment()->getMethod());
+            $billingAddress = $orderRow->getBillingAddress();
+            $order['postal_code'] = $billingAddress ? $billingAddress->getPostCode() : '';
+            $order['country_code'] = $billingAddress ? $billingAddress->getCountryId() : '';
+            $order['status'] = $this->mapOrderStatus(is_string($order['raw_status']) ? $order['raw_status'] : '');
+            $payment = $orderRow->getPayment();
+            $order['payment_method_raw'] = $payment ? $payment->getAdditionalInformation()['method_title'] : '';
+            $order['payment_method'] = $payment ? $this->mapPaymentName($payment->getMethod()) : '';
 
             $orders[] = $order;
         }

--- a/Model/Api/Builders/CreateOrderRequestBuilder.php
+++ b/Model/Api/Builders/CreateOrderRequestBuilder.php
@@ -193,7 +193,7 @@ class CreateOrderRequestBuilder implements \SeQura\Core\BusinessLogic\Domain\Ord
                 if (!empty($generalSettings['excludedCategories']) &&
                     !empty(array_intersect(
                         $generalSettings['excludedCategories'],
-                        $this->productService->getAllProductCategories($item->getProduct()->getCategoryIds())
+                        $this->productService->getAllProductCategoryIds($item->getProduct()->getCategoryIds())
                     ))
                 ) {
                     return false;

--- a/Services/BusinessLogic/ProductService.php
+++ b/Services/BusinessLogic/ProductService.php
@@ -39,11 +39,11 @@ class ProductService
      *
      * @param array<string> $categoryIds
      *
-     * @return array<int>
+     * @return array<string>
      *
      * @throws NoSuchEntityException
      */
-    public function getAllProductCategories(array $categoryIds): array
+    public function getAllProductCategoryIds(array $categoryIds): array
     {
         if (!$categoryIds) {
             return [];
@@ -55,7 +55,7 @@ class ProductService
             $trails[] = $this->getTrail($categoryId);
         }
 
-        return array_merge(...$trails);
+        return array_unique(array_merge(...$trails));
     }
 
     /**
@@ -63,7 +63,7 @@ class ProductService
      *
      * @param string $categoryId
      *
-     * @return array<int>
+     * @return array<string>
      *
      * @throws NoSuchEntityException
      */
@@ -75,17 +75,11 @@ class ProductService
 
         $storeId = (int) StoreContext::getInstance()->getStoreId();
         $category = $this->categoryRepository->get((int) $categoryId, $storeId);
-        $categoryTree = $this->categoryTree
-        ->setStoreId($storeId)
-        ->loadBreadcrumbsArray($category->getPath() ?? '');
-
-        $categoryTrailArray = [];
-        foreach ($categoryTree as $eachCategory) {
-            $categoryTrailArray[] = $eachCategory['entity_id'];
+        $categories = explode('/', $category->getPath() ?? '');
+        if (count($categories) < 2) {
+            return [];
         }
-
-        $this->resolvedCategories[$categoryId] = $categoryTrailArray;
-
-        return $categoryTrailArray;
+        unset($categories[0]);
+        return $categories;
     }
 }

--- a/Services/BusinessLogic/ProductService.php
+++ b/Services/BusinessLogic/ProductService.php
@@ -10,27 +10,19 @@ use SeQura\Core\BusinessLogic\Domain\Multistore\StoreContext;
 class ProductService
 {
     /**
-     * @var Tree
-     */
-    private $categoryTree;
-    /**
      * @var CategoryRepositoryInterface
      */
     private $categoryRepository;
     /**
-     * @var array<string, array<int>>
+     * @var array<string, array<string>>
      */
     private $resolvedCategories = [];
 
     /**
-     * @param Tree $categoryTree
      * @param CategoryRepositoryInterface $categoryRepository
      */
-    public function __construct(
-        Tree $categoryTree,
-        CategoryRepositoryInterface $categoryRepository
-    ) {
-        $this->categoryTree = $categoryTree;
+    public function __construct(CategoryRepositoryInterface $categoryRepository)
+    {
         $this->categoryRepository = $categoryRepository;
     }
 

--- a/bin/xdebug
+++ b/bin/xdebug
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker compose exec magento toggle-xdebug
+docker compose exec magento toggle-xdebug $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - m2_html:/var/www/html
       - .:/Sequra/Core:ro
       - ./.docker/magento/HelperModule/Sequra:/var/www/html/app/code/Sequra
+      - ./.docker/magento/xdebug-profile:/tmp/xdebug
     extra_hosts:
       - "host.docker.internal:host-gateway" # For XDebug to work properly on Linux
       - "${M2_HTTP_HOST}:host-gateway"


### PR DESCRIPTION
 ### What is the goal?

Fix performance issues in category validation

 ### References
* **Issue:** PAR-547

 ### How is it being implemented?

This pull request introduces enhancements to the XDebug toggle script, refactors product category handling, and updates the Docker configuration. The most significant changes include adding support for XDebug modes, refactoring methods for retrieving product category IDs, and modifying Docker volumes for XDebug profiling.

#### XDebug Enhancements:
* [`.docker/magento/toggle-xdebug.sh`](diffhunk://#diff-c822bd115a8fe2626786b8b3bc15952d470a50aa0553906f2570d39eada7d61aL2-R35): Rewrote the script to support `debug` and `profile` modes for XDebug. Added argument parsing, improved configuration handling, and updated logging messages.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R19): Added a new volume mapping for XDebug profiling output (`./.docker/magento/xdebug-profile:/tmp/xdebug`).

#### Product Category Refactoring:
* [`Services/BusinessLogic/ProductService.php`](diffhunk://#diff-129eef2778fdd30add2d32fd47c7015170cee9385abf63acdfa9e3f3b5f7a9f9L42-R46): Renamed `getAllProductCategories` to `getAllProductCategoryIds` and updated the return type to `array<string>`. Simplified the `getTrail` method to directly parse category paths and removed redundant logic. Ensured unique category IDs in the returned array. [[1]](diffhunk://#diff-129eef2778fdd30add2d32fd47c7015170cee9385abf63acdfa9e3f3b5f7a9f9L42-R46) [[2]](diffhunk://#diff-129eef2778fdd30add2d32fd47c7015170cee9385abf63acdfa9e3f3b5f7a9f9L58-R66) [[3]](diffhunk://#diff-129eef2778fdd30add2d32fd47c7015170cee9385abf63acdfa9e3f3b5f7a9f9L78-R83)

* [`Gateway/Validator/ProductWidgetAvailabilityValidator.php`](diffhunk://#diff-62abdad8980112c78353adb61a3fade83ff012f0356d7e70946331786ad37c12L106-R126): Updated logic to handle empty excluded categories and refactored calls to use the renamed `getAllProductCategoryIds` method.

* [`Model/Api/Builders/CreateOrderRequestBuilder.php`](diffhunk://#diff-efcd345ad9e59ecbc1e0aa0b330e77f736fb164b86f340a5889128528983dfcfL196-R196): Updated to use the renamed `getAllProductCategoryIds` method for checking excluded categories.

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

Standard deployment
