### PR TITLE
Release version 2.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "pagos",
         "magento2"
     ],
-    "version": "2.6.0",
+    "version": "2.6.1",
     "license": "MIT",
     "authors": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sequra_Core" setup_version="2.6.0">
+    <module name="Sequra_Core" setup_version="2.6.1">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
 ### What is the goal?

Release version 2.6.1

### How is it being implemented?

This pull request includes a version bump for the `Sequra_Core` module from `2.6.0` to `2.6.1`. The changes ensure consistency across configuration and metadata files. It also bumps the required version of the integration-core package to v1.1.1

 ### How is it tested?

Automatic tests and Manual tests (widgets)

 ### How is it going to be deployed?

Standard deployment
