### PR TITLE
Chore/use integration core version 2.0.0

### DIFF
--- a/bin/update-sequra
+++ b/bin/update-sequra
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Updating Sequra_Core source code"
-docker compose exec -u www-data magento /bin/bash -c "COMPOSER_MIRROR_PATH_REPOS=1 composer reinstall sequra/magento2-core && bin/magento module:enable --clear-static-content Sequra_Core && bin/magento setup:upgrade && bin/magento setup:di:compile"
+docker compose exec -u www-data magento /bin/bash -c "COMPOSER_MIRROR_PATH_REPOS=1 composer update sequra/magento2-core --with-dependencies && bin/magento module:enable --clear-static-content Sequra_Core && bin/magento setup:upgrade && bin/magento setup:di:compile"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.4",
-        "sequra/integration-core": "dev-master",
+        "sequra/integration-core": "v2.0.0",
         "ext-json": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.4",
-        "sequra/integration-core": "v2.0.0",
+        "sequra/integration-core": "^v2.0.0",
         "ext-json": "*"
     },
     "autoload": {


### PR DESCRIPTION
 ### What is the goal?

Use the integration-core v2.0.0

 ### How is it being implemented?

This pull request updates the dependency version for `sequra/integration-core` in the `composer.json` file. The change replaces the `dev-master` version with `v2.0.0` to ensure stability and compatibility with the latest release.

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

Standard deployment
