### PR TITLE
Bugfix/par 560 allow refunding shipped orders

### DIFF
--- a/Services/BusinessLogic/Utility/TransformEntityService.php
+++ b/Services/BusinessLogic/Utility/TransformEntityService.php
@@ -102,7 +102,8 @@ class TransformEntityService
     {
         $items = [];
         $cartSubTotal = self::cartSubTotal($orderData);
-        $shippedRatio = self::isFullyShipped($orderData) ? 1 : $cartSubTotal['shipped'] / ($cartSubTotal['shipped'] + $cartSubTotal['unshipped']);
+        $shippedRatio = self::isFullyShipped($orderData) ?
+            1 : $cartSubTotal['shipped'] / ($cartSubTotal['shipped'] + $cartSubTotal['unshipped']);
         $unShippedRatio = 1 - $shippedRatio;
         $ratio = ($isShipped ) ? $shippedRatio : $unShippedRatio;
         /** @var MagentoOrder\Item $orderItem */
@@ -113,7 +114,7 @@ class TransformEntityService
             $refundedQty = $orderItem->getQtyRefunded() ? (int)$orderItem->getQtyRefunded() : 0;
             $quantityToRefund = ($isShipped) ? max(0, $refundedQty - $unshippedQty) : min($refundedQty, $unshippedQty);
             $quantity = ($isShipped) ? $shippedQty - $quantityToRefund : $unshippedQty - $quantityToRefund;
-            if ($quantity <= 0 ) {
+            if ($quantity <= 0) {
                 continue;
             }
             $product = $orderItem->getProduct();
@@ -134,7 +135,8 @@ class TransformEntityService
 
         $refundedShippingAmount = $orderData->getShippingRefunded() ?
         self::transformPrice($orderData->getShippingRefunded()) : 0;
-        $shippingAmount = $orderData->getShippingInclTax() ? self::transformPrice($orderData->getShippingInclTax()) : 0;
+        $shippingAmount = $orderData->getShippingInclTax() ?
+            self::transformPrice($orderData->getShippingInclTax()) : 0;
         $totalShipmentCost = round(($shippingAmount - $refundedShippingAmount) * $ratio);
         if ($totalShipmentCost > 0) {
             $items[] = HandlingItem::fromArray([
@@ -183,12 +185,16 @@ class TransformEntityService
         }, 0);
 
         if ($cartTotal < 0) {
-            throw new LocalizedException($this->translationProvider->translate('sequra.error.invalidRefundAmount'));
+            throw new LocalizedException(
+                $this->translationProvider->translate('sequra.error.invalidRefundAmount')
+            );
         }
 
         return $items;
     }
-
+    // TODO: Static method cannot be intercepted and its use is discouraged.
+    // phpcs:disable Magento2.Functions.StaticFunction.StaticFunction
+    
     /**
      * Calculates the subtotal of the cart.
      *
@@ -207,9 +213,15 @@ class TransformEntityService
             $orderedQty = $orderItem->getQtyOrdered() ? (int)$orderItem->getQtyOrdered() : 0;
             $unshippedQty = $orderItem->getQtyOrdered() - $shippedQty;
             $refundedQty = $orderItem->getQtyRefunded() ? (int)$orderItem->getQtyRefunded() : 0;
-            $shippedSubtotal += self::transformPrice(($orderItem->getRowTotalInclTax() ?? 0) * $shippedQty / $orderedQty) ;
-            $unShippedSubtotal += self::transformPrice(($orderItem->getRowTotalInclTax() ?? 0) * $unshippedQty / $orderedQty);
-            $refundedSubtotal += self::transformPrice(($orderItem->getRowTotalInclTax() ?? 0) * $refundedQty / $orderedQty);
+            $shippedSubtotal += self::transformPrice(
+                ($orderItem->getRowTotalInclTax() ?? 0) * $shippedQty / $orderedQty
+            ) ;
+            $unShippedSubtotal += self::transformPrice(
+                ($orderItem->getRowTotalInclTax() ?? 0) * $unshippedQty / $orderedQty
+            );
+            $refundedSubtotal += self::transformPrice(
+                ($orderItem->getRowTotalInclTax() ?? 0) * $refundedQty / $orderedQty
+            );
         }
         return ['shipped' => $shippedSubtotal, 'unshipped' => $unShippedSubtotal, 'refunded' => $refundedSubtotal];
     }
@@ -228,16 +240,13 @@ class TransformEntityService
             $shippedQty = $orderItem->getQtyShipped() ? (int)$orderItem->getQtyShipped() : 0;
             $orderedQty = $orderItem->getQtyOrdered() ? (int)$orderItem->getQtyOrdered() : 0;
             $refundedQty = $orderItem->getQtyRefunded() ? (int)$orderItem->getQtyRefunded() : 0;
-            if($orderedQty - $shippedQty - $refundedQty > 0) {
+            if ($orderedQty - $shippedQty - $refundedQty > 0) {
                 return false;
             }
         }
         return true;
     }
 
-    // TODO: Static method cannot be intercepted and its use is discouraged.
-    // phpcs:disable Magento2.Functions.StaticFunction.StaticFunction
-    
     /**
      * Transform price to format.
      *

--- a/Services/BusinessLogic/Utility/TransformEntityService.php
+++ b/Services/BusinessLogic/Utility/TransformEntityService.php
@@ -206,13 +206,11 @@ class TransformEntityService
     {
         $shippedSubtotal = 0;
         $unShippedSubtotal = 0;
-        $refundedSubtotal = 0;
         /** @var MagentoOrder\Item $orderItem */
         foreach ($orderData->getAllVisibleItems() as $orderItem) {
             $shippedQty = $orderItem->getQtyShipped() ? (int)$orderItem->getQtyShipped() : 0;
             $orderedQty = $orderItem->getQtyOrdered() ? (int)$orderItem->getQtyOrdered() : 0;
             $unshippedQty = $orderItem->getQtyOrdered() - $shippedQty;
-            $refundedQty = $orderItem->getQtyRefunded() ? (int)$orderItem->getQtyRefunded() : 0;
             if ($orderedQty > 0) {
                 $shippedSubtotal += self::transformPrice(
                     ($orderItem->getRowTotalInclTax() ?? 0) * $shippedQty / $orderedQty
@@ -220,12 +218,9 @@ class TransformEntityService
                 $unShippedSubtotal += self::transformPrice(
                     ($orderItem->getRowTotalInclTax() ?? 0) * $unshippedQty / $orderedQty
                 );
-                $refundedSubtotal += self::transformPrice(
-                    ($orderItem->getRowTotalInclTax() ?? 0) * $refundedQty / $orderedQty
-                );
             }
         }
-        return ['shipped' => $shippedSubtotal, 'unshipped' => $unShippedSubtotal, 'refunded' => $refundedSubtotal];
+        return ['shipped' => $shippedSubtotal, 'unshipped' => $unShippedSubtotal];
     }
 
     /**

--- a/Services/BusinessLogic/Utility/TransformEntityService.php
+++ b/Services/BusinessLogic/Utility/TransformEntityService.php
@@ -210,7 +210,7 @@ class TransformEntityService
         foreach ($orderData->getAllVisibleItems() as $orderItem) {
             $shippedQty = $orderItem->getQtyShipped() ? (int)$orderItem->getQtyShipped() : 0;
             $orderedQty = $orderItem->getQtyOrdered() ? (int)$orderItem->getQtyOrdered() : 0;
-            $unshippedQty = $orderItem->getQtyOrdered() - $shippedQty;
+            $unshippedQty = $orderedQty - $shippedQty;
             if ($orderedQty > 0) {
                 $shippedSubtotal += self::transformPrice(
                     ($orderItem->getRowTotalInclTax() ?? 0) * $shippedQty / $orderedQty

--- a/Services/BusinessLogic/Utility/TransformEntityService.php
+++ b/Services/BusinessLogic/Utility/TransformEntityService.php
@@ -213,15 +213,17 @@ class TransformEntityService
             $orderedQty = $orderItem->getQtyOrdered() ? (int)$orderItem->getQtyOrdered() : 0;
             $unshippedQty = $orderItem->getQtyOrdered() - $shippedQty;
             $refundedQty = $orderItem->getQtyRefunded() ? (int)$orderItem->getQtyRefunded() : 0;
-            $shippedSubtotal += self::transformPrice(
-                ($orderItem->getRowTotalInclTax() ?? 0) * $shippedQty / $orderedQty
-            ) ;
-            $unShippedSubtotal += self::transformPrice(
-                ($orderItem->getRowTotalInclTax() ?? 0) * $unshippedQty / $orderedQty
-            );
-            $refundedSubtotal += self::transformPrice(
-                ($orderItem->getRowTotalInclTax() ?? 0) * $refundedQty / $orderedQty
-            );
+            if ($orderedQty > 0) {
+                $shippedSubtotal += self::transformPrice(
+                    ($orderItem->getRowTotalInclTax() ?? 0) * $shippedQty / $orderedQty
+                );
+                $unShippedSubtotal += self::transformPrice(
+                    ($orderItem->getRowTotalInclTax() ?? 0) * $unshippedQty / $orderedQty
+                );
+                $refundedSubtotal += self::transformPrice(
+                    ($orderItem->getRowTotalInclTax() ?? 0) * $refundedQty / $orderedQty
+                );
+            }
         }
         return ['shipped' => $shippedSubtotal, 'unshipped' => $unShippedSubtotal, 'refunded' => $refundedSubtotal];
     }

--- a/Services/BusinessLogic/Utility/TransformEntityService.php
+++ b/Services/BusinessLogic/Utility/TransformEntityService.php
@@ -164,7 +164,7 @@ class TransformEntityService
             $items[] = new OtherPaymentItem(
                 'additional_discount',
                 'Refund adjustment',
-                self::transformPrice($adjustmentPositive)
+                -1 * self::transformPrice($adjustmentPositive)
             );
 
         }
@@ -194,7 +194,7 @@ class TransformEntityService
     }
     // TODO: Static method cannot be intercepted and its use is discouraged.
     // phpcs:disable Magento2.Functions.StaticFunction.StaticFunction
-    
+
     /**
      * Calculates the subtotal of the cart.
      *


### PR DESCRIPTION
### What is the goal?

_Provide a description of the overall goal (you can usually use the one from the issue)_

 ### References
* **Issue:** PAR-560

 ### How is it being implemented?

This pull request refactors the `TransformEntityService` class to simplify order item transformations and improve handling of shipping, discounts, and adjustments. The changes introduce new utility methods to calculate cart subtotals and determine shipping statuses, while removing redundant logic and unnecessary methods.

### Refactoring and Utility Enhancements:
* Added `cartSubTotal` and `isFullyShipped` methods to calculate cart subtotals and determine if an order is fully shipped, improving clarity and modularity.
* Removed the `isCartEmpty` method, as its functionality is no longer required due to the updated logic.

### Improved Handling of Shipping and Discounts:
* Refactored shipping amount calculations to use a ratio based on shipping status, ensuring accurate handling of shipping costs during partial shipments.
* Updated discount calculations to apply the same ratio logic, simplifying the handling of refunded and unshipped discounts.

### Adjustments and Error Handling:
* Enhanced handling of positive and negative adjustments by introducing `OtherPaymentItem` and `HandlingItem` instances for refund adjustments.
* Improved error handling for invalid refund amounts by reformatting exception logic for better readability.

 ### Opportunistic refactorings

 ### Caveats

### Does it affect (changes or update) any sensitive data?

### How is it going to be deployed?

Standard deployment
