### PR TITLE
Add support to new magento versions

### DIFF
--- a/.docker/magento/Dockerfile.php8
+++ b/.docker/magento/Dockerfile.php8
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sockets \
     xsl \
     zip \
+    ftp \
     && docker-php-ext-enable \
     redis \
     xdebug \

--- a/.docker/magento/HelperModule/Sequra/Helper/Console/Setup.php
+++ b/.docker/magento/HelperModule/Sequra/Helper/Console/Setup.php
@@ -7,8 +7,8 @@ namespace Sequra\Helper\Console;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Magento\Framework\App\State;
 
 /**
  * Console command to trigger DR report
@@ -19,6 +19,22 @@ class Setup extends Command
      *  Command name
      */
     public const NAME = 'sequra-helper:setup';
+
+    /**
+     * @var State
+     */
+    private $state;
+
+     /**
+      * ProcessSubscriptionsCommand constructor.
+      * @param State $state
+      * @param ObjectManagerInterface $objectManager
+      */
+    public function __construct(State $state)
+    {
+        parent::__construct();
+        $this->state = $state;
+    }
     
    /**
     * Initialize triggerreport command
@@ -41,6 +57,29 @@ class Setup extends Command
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            return $this->state->emulateAreaCode(
+                \Magento\Framework\App\Area::AREA_ADMINHTML,
+                [$this, "executeCallBack"],
+                [$input, $output]
+            );
+        } catch (\Exception $e) {
+            $output->writeln($e->getMessage());
+            return 1;
+        }
+    }
+
+    /**
+     * Callback function to execute the command.
+     *
+     * @param InputInterface  $input  InputInterface
+     * @param OutputInterface $output OutputInterface
+     *
+     * @return int 0 if everything went fine, or an exit code
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function executeCallBack(InputInterface $input, OutputInterface $output)
     {
         if (empty(getenv('M2_SAMPLE_DATA'))) {
             $output->writeln("Skip setup, M2_SAMPLE_DATA is not set");
@@ -75,7 +114,7 @@ class Setup extends Command
         }
        
         $customerRepository->save($customer);
-        $output->writeln("Dirección actualizada correctamente");
+        $output->writeln("Address updated successfully");
         return 0;
     }
 }

--- a/.docker/magento/HelperModule/Sequra/Helper/Console/Setup.php
+++ b/.docker/magento/HelperModule/Sequra/Helper/Console/Setup.php
@@ -58,11 +58,15 @@ class Setup extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            return $this->state->emulateAreaCode(
+            /**
+             * @var int $result
+             */
+            $result = $this->state->emulateAreaCode(
                 \Magento\Framework\App\Area::AREA_ADMINHTML,
                 [$this, "executeCallBack"],
                 [$input, $output]
             );
+            return $result;
         } catch (\Exception $e) {
             $output->writeln($e->getMessage());
             return 1;
@@ -75,7 +79,7 @@ class Setup extends Command
      * @param InputInterface  $input  InputInterface
      * @param OutputInterface $output OutputInterface
      *
-     * @return int 0 if everything went fine, or an exit code
+     * @return int
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function executeCallBack(InputInterface $input, OutputInterface $output)

--- a/.docker/magento/HelperModule/Sequra/Helper/Console/Setup.php
+++ b/.docker/magento/HelperModule/Sequra/Helper/Console/Setup.php
@@ -26,9 +26,8 @@ class Setup extends Command
     private $state;
 
      /**
-      * ProcessSubscriptionsCommand constructor.
+      * Constructor.
       * @param State $state
-      * @param ObjectManagerInterface $objectManager
       */
     public function __construct(State $state)
     {

--- a/.docker/magento/build-image.sh
+++ b/.docker/magento/build-image.sh
@@ -54,14 +54,27 @@ if [ -z "$PHP_VERSION" ]; then
 fi
 
 # Check if the PHP version is supported
-if [ "$PHP_VERSION" != "7.4" ] && [ "$PHP_VERSION" != "8.1" ] && [ "$PHP_VERSION" != "8.2" ] && [ "$PHP_VERSION" != "8.3" ]; then
-    echo "❌ PHP version $PHP_VERSION is not supported. Supported versions are 7.4, 8.1, 8.2, 8.3"
+if [ "$PHP_VERSION" != "7.4" ] \
+&& [ "$PHP_VERSION" != "8.1" ] \
+&& [ "$PHP_VERSION" != "8.2" ] \
+&& [ "$PHP_VERSION" != "8.3" ] \
+&& [ "$PHP_VERSION" != "8.4" ]; then
+    echo "❌ PHP version $PHP_VERSION is not supported. Supported versions are 7.4, 8.1, 8.2, 8.3, 8.4"
     exit 1
 fi
 
 # Check if the Magento version is supported
-if [ "$M2_VERSION" != "2.4.3-p3" ] && [ "$M2_VERSION" != "2.4.4-p11" ] && [ "$M2_VERSION" != "2.4.5-p10" ] && [ "$M2_VERSION" != "2.4.6-p8" ] && [ "$M2_VERSION" != "2.4.7-p3" ] && [ "$M2_VERSION" != "2.4.7-p4" ] && [ "$M2_VERSION" != "2.4.7-p5" ] && [ "$M2_VERSION" != "2.4.8" ]; then
-    echo "❌ Magento version $M2_VERSION is not supported. Supported versions are 2.4.3-p3, 2.4.4-p11, 2.4.5-p10, 2.4.6-p8, 2.4.7-p3, 2.4.7-p4, 2.4.7-p5, 2.4.8"
+if [ "$M2_VERSION" != "2.4.3-p3" ] \
+&& [ "$M2_VERSION" != "2.4.4-p11" ] \
+&& [ "$M2_VERSION" != "2.4.5-p10" ] \
+&& [ "$M2_VERSION" != "2.4.6-p8" ] \
+&& [ "$M2_VERSION" != "2.4.7-p3" ] \
+&& [ "$M2_VERSION" != "2.4.7-p4" ] \
+&& [ "$M2_VERSION" != "2.4.7-p5" ] \
+&& [ "$M2_VERSION" != "2.4.7-p6" ] \
+&& [ "$M2_VERSION" != "2.4.8" ] \
+&& [ "$M2_VERSION" != "2.4.8-p1" ]; then
+    echo "❌ Magento version $M2_VERSION is not supported. Supported versions are 2.4.3-p3, 2.4.4-p11, 2.4.5-p10, 2.4.6-p8, 2.4.7-p3, 2.4.7-p4, 2.4.7-p5, 2.4.7-p6, 2.4.8, 2.4.8-p1"
     exit 1
 fi
 
@@ -96,8 +109,13 @@ if [ "$M2_VERSION" == "2.4.7-p4" ] && [ "$PHP_VERSION" != "8.2" ]; then
     exit 1
 fi
 
-if { [ "$M2_VERSION" == "2.4.7-p5" ] || [ "$M2_VERSION" == "2.4.8" ]; } && [ "$PHP_VERSION" != "8.3" ]; then
+if { [ "$M2_VERSION" == "2.4.7-p5" ] || [ "$M2_VERSION" == "2.4.7-p6" ]; } && [ "$PHP_VERSION" != "8.3" ]; then
     echo "❌ Magento version $M2_VERSION is not compatible with PHP version $PHP_VERSION. Please use PHP version 8.3"
+    exit 1
+fi
+
+if { [ "$M2_VERSION" == "2.4.8" ] || [ "$M2_VERSION" == "2.4.8-p1" ]; } && [ "$PHP_VERSION" != "8.4" ]; then
+    echo "❌ Magento version $M2_VERSION is not compatible with PHP version $PHP_VERSION. Please use PHP version 8.4"
     exit 1
 fi
 

--- a/.docker/magento/build-image.sh
+++ b/.docker/magento/build-image.sh
@@ -114,8 +114,8 @@ if { [ "$M2_VERSION" == "2.4.7-p5" ] || [ "$M2_VERSION" == "2.4.7-p6" ]; } && [ 
     exit 1
 fi
 
-if { [ "$M2_VERSION" == "2.4.8" ] || [ "$M2_VERSION" == "2.4.8-p1" ]; } && [ "$PHP_VERSION" != "8.4" ]; then
-    echo "❌ Magento version $M2_VERSION is not compatible with PHP version $PHP_VERSION. Please use PHP version 8.4"
+if { [ "$M2_VERSION" == "2.4.8" ] || [ "$M2_VERSION" == "2.4.8-p1" ]; } && { [ "$PHP_VERSION" != "8.3" ] && [ "$PHP_VERSION" != "8.4" ]; }; then
+    echo "❌ Magento version $M2_VERSION is not compatible with PHP version $PHP_VERSION. Please use PHP version 8.3 or 8.4"
     exit 1
 fi
 

--- a/.docker/magento/build-image.sh
+++ b/.docker/magento/build-image.sh
@@ -54,14 +54,14 @@ if [ -z "$PHP_VERSION" ]; then
 fi
 
 # Check if the PHP version is supported
-if [ "$PHP_VERSION" != "7.4" ] && [ "$PHP_VERSION" != "8.1" ] && [ "$PHP_VERSION" != "8.2" ]; then
-    echo "❌ PHP version $PHP_VERSION is not supported. Supported versions are 7.4, 8.1, 8.2"
+if [ "$PHP_VERSION" != "7.4" ] && [ "$PHP_VERSION" != "8.1" ] && [ "$PHP_VERSION" != "8.2" ] && [ "$PHP_VERSION" != "8.3" ]; then
+    echo "❌ PHP version $PHP_VERSION is not supported. Supported versions are 7.4, 8.1, 8.2, 8.3"
     exit 1
 fi
 
 # Check if the Magento version is supported
-if [ "$M2_VERSION" != "2.4.3-p3" ] && [ "$M2_VERSION" != "2.4.4-p11" ] && [ "$M2_VERSION" != "2.4.5-p10" ] && [ "$M2_VERSION" != "2.4.6-p8" ] && [ "$M2_VERSION" != "2.4.7-p3" ] && [ "$M2_VERSION" != "2.4.7-p4" ]; then
-    echo "❌ Magento version $M2_VERSION is not supported. Supported versions are 2.4.3-p3, 2.4.4-p11, 2.4.5-p10, 2.4.6-p8, 2.4.7-p3, 2.4.7-p4"
+if [ "$M2_VERSION" != "2.4.3-p3" ] && [ "$M2_VERSION" != "2.4.4-p11" ] && [ "$M2_VERSION" != "2.4.5-p10" ] && [ "$M2_VERSION" != "2.4.6-p8" ] && [ "$M2_VERSION" != "2.4.7-p3" ] && [ "$M2_VERSION" != "2.4.7-p4" ] && [ "$M2_VERSION" != "2.4.7-p5" ] && [ "$M2_VERSION" != "2.4.8" ]; then
+    echo "❌ Magento version $M2_VERSION is not supported. Supported versions are 2.4.3-p3, 2.4.4-p11, 2.4.5-p10, 2.4.6-p8, 2.4.7-p3, 2.4.7-p4, 2.4.7-p5, 2.4.8"
     exit 1
 fi
 
@@ -93,6 +93,11 @@ fi
 
 if [ "$M2_VERSION" == "2.4.7-p4" ] && [ "$PHP_VERSION" != "8.2" ]; then
     echo "❌ Magento version $M2_VERSION is not compatible with PHP version $PHP_VERSION. Please use PHP version 8.2"
+    exit 1
+fi
+
+if { [ "$M2_VERSION" == "2.4.7-p5" ] || [ "$M2_VERSION" == "2.4.8" ]; } && [ "$PHP_VERSION" != "8.3" ]; then
+    echo "❌ Magento version $M2_VERSION is not compatible with PHP version $PHP_VERSION. Please use PHP version 8.3"
     exit 1
 fi
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 # The version of MariaDB to use. See available tags at https://hub.docker.com/_/mariadb/tags
-MARIADB_TAG=10.6 # Compatible with Magento 2.4.7, 2.4.6
+# MARIADB_TAG=11.4 # Compatible with Magento 2.4.8
+MARIADB_TAG=10.6 # Compatible with Magento 2.4.7, 2.4.6, 2.4.7
 # MARIADB_TAG=10.5 # Compatible with Magento 2.4.5, 2.4.4
 # MARIADB_TAG=10.4 # Compatible with Magento 2.4.3
 
@@ -21,7 +22,8 @@ REDIS_TAG=7.2 # Compatible with Magento 2.4.7, 2.4.6, 2.4.5, 2.4.4
 # The port to expose the Redis service
 REDIS_PORT=6380
 
-OPENSEARCH_TAG=2.12.0 # Use this version for Magento 2.4.7, 2.4.6-p5 - 2.4.6-p9
+OPENSEARCH_TAG=2.19.2 # Use this version for Magento 2.4.7-p5, 2.4.8
+# OPENSEARCH_TAG=2.12.0 # Use this version for Magento 2.4.7, 2.4.6-p5 - 2.4.6-p9
 # OPENSEARCH_TAG=2.5.0 # Use this version for Magento 2.4.6 - 2.4.6-p4
 # OPENSEARCH_TAG=1.3.20 # Use this version for Magento 2.4.5-p11
 # OPENSEARCH_TAG=1.3.0 # Use this version for Magento  2.4.4-p8 - 2.4.4-p11, 2.4.5-p7 - 2.4.5-p10
@@ -30,8 +32,10 @@ OPENSEARCH_API_PORT=9201
 OPENSEARCH_INTERNODE_PORT=9600
 
 # The version of Elasticsearch to use. See available tags at https://hub.docker.com/_/elasticsearch/tags
-# ELASTICSEARCH_TAG=8.11.4 # Use this version for Magento 2.4.7
-ELASTICSEARCH_TAG=7.16.3 # Use this version for Magento 2.4.3, 2.4.4, 2.4.5, 2.4.6
+ELASTICSEARCH_TAG=8.17.6 # Use this version for Magento 2.4.7-p5
+# ELASTICSEARCH_TAG=8.16.6 # Use this version for Magento 2.4.7-p4
+# ELASTICSEARCH_TAG=8.11.4 # Use this version for Magento 2.4.7 - 2.4.7-p3
+# ELASTICSEARCH_TAG=7.16.3 # Use this version for Magento 2.4.3, 2.4.4, 2.4.5, 2.4.6
 
 # The port to expose the Elasticsearch service
 ELASTICSEARCH_API_PORT=9200

--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@ MARIADB_PORT=3328
 
 # The version of Redis to use. See available tags at https://hub.docker.com/_/redis/tags
 # REDIS_TAG=6 # Compatible with Magento 2.4.3
-REDIS_TAG=7.2 # Compatible with Magento 2.4.7, 2.4.6, 2.4.5, 2.4.4
+REDIS_TAG=7.2 # Compatible with Magento 2.4.8, 2.4.7, 2.4.6, 2.4.5, 2.4.4
 # The port to expose the Redis service
 REDIS_PORT=6380
 
@@ -42,7 +42,8 @@ ELASTICSEARCH_API_PORT=9200
 ELASTICSEARCH_INTERNODE_PORT=9300
 
 # The version of PHP to use.
-PHP_VERSION=8.2 # Compatible with Magento 2.4.7, 2.4.6
+PHP_VERSION=8.3 # Compatible with Magento 2.4.7-p5, 2.4.8
+# PHP_VERSION=8.2 # Compatible with Magento 2.4.7 - 2.4.7-p4, 2.4.6
 # PHP_VERSION=8.1 # Compatible with Magento 2.4.5, 2.4.4
 # PHP_VERSION=7.4 # Compatible with Magento 2.4.3
 
@@ -52,7 +53,9 @@ PHP_VERSION=8.2 # Compatible with Magento 2.4.7, 2.4.6
 # M2_VERSION=2.4.5-p10
 # M2_VERSION=2.4.6-p8
 # M2_VERSION=2.4.7-p3
-M2_VERSION=2.4.7-p4
+# M2_VERSION=2.4.7-p4
+M2_VERSION=2.4.7-p5
+# M2_VERSION=2.4.8
 
 # The hostname of the database server
 M2_DB_HOST=mariadb

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # The version of MariaDB to use. See available tags at https://hub.docker.com/_/mariadb/tags
 # MARIADB_TAG=11.4 # Compatible with Magento 2.4.8
-MARIADB_TAG=10.6 # Compatible with Magento 2.4.7, 2.4.6, 2.4.7
+MARIADB_TAG=10.11 # Compatible with Magento 2.4.7-p6
+# MARIADB_TAG=10.6 # Compatible with Magento 2.4.7, 2.4.6, 2.4.7 - 2.4.7-p5
 # MARIADB_TAG=10.5 # Compatible with Magento 2.4.5, 2.4.4
 # MARIADB_TAG=10.4 # Compatible with Magento 2.4.3
 
@@ -22,7 +23,7 @@ REDIS_TAG=7.2 # Compatible with Magento 2.4.8, 2.4.7, 2.4.6, 2.4.5, 2.4.4
 # The port to expose the Redis service
 REDIS_PORT=6380
 
-OPENSEARCH_TAG=2.19.2 # Use this version for Magento 2.4.7-p5, 2.4.8
+OPENSEARCH_TAG=2.19.2 # Use this version for Magento 2.4.7-p5, 2.4.7-p6, 2.4.8
 # OPENSEARCH_TAG=2.12.0 # Use this version for Magento 2.4.7, 2.4.6-p5 - 2.4.6-p9
 # OPENSEARCH_TAG=2.5.0 # Use this version for Magento 2.4.6 - 2.4.6-p4
 # OPENSEARCH_TAG=1.3.20 # Use this version for Magento 2.4.5-p11
@@ -42,7 +43,8 @@ ELASTICSEARCH_API_PORT=9200
 ELASTICSEARCH_INTERNODE_PORT=9300
 
 # The version of PHP to use.
-PHP_VERSION=8.3 # Compatible with Magento 2.4.7-p5, 2.4.8
+# PHP_VERSION=8.4 # Compatible with Magento 2.4.8
+PHP_VERSION=8.3 # Compatible with Magento 2.4.7-p5, 2.4.7-p6, 2.4.8
 # PHP_VERSION=8.2 # Compatible with Magento 2.4.7 - 2.4.7-p4, 2.4.6
 # PHP_VERSION=8.1 # Compatible with Magento 2.4.5, 2.4.4
 # PHP_VERSION=7.4 # Compatible with Magento 2.4.3
@@ -54,8 +56,10 @@ PHP_VERSION=8.3 # Compatible with Magento 2.4.7-p5, 2.4.8
 # M2_VERSION=2.4.6-p8
 # M2_VERSION=2.4.7-p3
 # M2_VERSION=2.4.7-p4
-M2_VERSION=2.4.7-p5
+# M2_VERSION=2.4.7-p5
+M2_VERSION=2.4.7-p6
 # M2_VERSION=2.4.8
+# M2_VERSION=2.4.8-p1
 
 # The hostname of the database server
 M2_DB_HOST=mariadb

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # The version of MariaDB to use. See available tags at https://hub.docker.com/_/mariadb/tags
-# MARIADB_TAG=11.4 # Compatible with Magento 2.4.8
-MARIADB_TAG=10.11 # Compatible with Magento 2.4.7-p6
+MARIADB_TAG=11.4 # Compatible with Magento 2.4.8
+# MARIADB_TAG=10.11 # Compatible with Magento 2.4.7-p6
 # MARIADB_TAG=10.6 # Compatible with Magento 2.4.7, 2.4.6, 2.4.7 - 2.4.7-p5
 # MARIADB_TAG=10.5 # Compatible with Magento 2.4.5, 2.4.4
 # MARIADB_TAG=10.4 # Compatible with Magento 2.4.3
@@ -57,9 +57,9 @@ PHP_VERSION=8.3 # Compatible with Magento 2.4.7-p5, 2.4.7-p6, 2.4.8
 # M2_VERSION=2.4.7-p3
 # M2_VERSION=2.4.7-p4
 # M2_VERSION=2.4.7-p5
-M2_VERSION=2.4.7-p6
+# M2_VERSION=2.4.7-p6
 # M2_VERSION=2.4.8
-# M2_VERSION=2.4.8-p1
+M2_VERSION=2.4.8-p1
 
 # The hostname of the database server
 M2_DB_HOST=mariadb

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.4 <8.4",
         "sequra/integration-core": "^2.1",
         "ext-json": "*"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     volumes:
       - m2_db:/var/lib/mysql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      test: [ "CMD", "sh", "-c", "mysqladmin ping -h localhost || mariadb-admin ping -h localhost" ]
       interval: 1s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
 ### What is the goal?

Add support to new Magento versions (2.4.7-p5, 2.4.7-p6,2.4.8, 2.4.8-p1)

 ### References
* **Issue:** PAR-553

 ### How is it being implemented?

This pull request introduces several updates to improve compatibility, enhance functionality, and refine error handling across the Magento Docker setup. Key changes include updates to PHP and Magento version support, adjustments to dependencies, and enhancements to the `Setup` console command.

#### Compatibility Updates:
* [`.docker/magento/build-image.sh`](diffhunk://#diff-753dbb6b58ad961be5f718a73caeda55dd4473a4e24899d4e2d82c277d75ae86L57-R77): Added support for PHP versions 8.3 and 8.4, and Magento versions 2.4.7-p5, 2.4.7-p6, 2.4.8, and 2.4.8-p1. Updated compatibility checks to ensure appropriate PHP versions are used with specific Magento versions. [[1]](diffhunk://#diff-753dbb6b58ad961be5f718a73caeda55dd4473a4e24899d4e2d82c277d75ae86L57-R77) [[2]](diffhunk://#diff-753dbb6b58ad961be5f718a73caeda55dd4473a4e24899d4e2d82c277d75ae86R112-R121)
* [`.env.sample`](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL2-R4): Updated default tags for MariaDB, Redis, OpenSearch, Elasticsearch, and PHP to reflect compatibility with newer Magento versions. Added comments to clarify compatibility for specific version combinations. [[1]](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL2-R4) [[2]](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL20-R27) [[3]](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL33-R48) [[4]](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cL51-R62)

#### Dependency Enhancements:
* [`.docker/magento/Dockerfile.php8`](diffhunk://#diff-42283b89e98169386f31aa4d6a8730d2ca15cddc6a7dd7f844e250465e66d557R35): Added the `ftp` extension to the list of installed PHP extensions to expand functionality.

#### Console Command Improvements:
* `.docker/magento/HelperModule/Sequra/Helper/Console/Setup.php`: 
  - Introduced dependency injection for `Magento\Framework\App\State` to emulate the admin area code during command execution. [[1]](diffhunk://#diff-f0b6895b4f113586101b3eed577da9d233f59c06efae439d277968e5f5dd4659L10-R11) [[2]](diffhunk://#diff-f0b6895b4f113586101b3eed577da9d233f59c06efae439d277968e5f5dd4659R23-R37)
  - Enhanced error handling in the `execute` method to catch exceptions and provide meaningful output. Added a callback method for encapsulating command logic.
  - Updated output messages for better readability and localization.

#### Miscellaneous Fixes:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L33-R33): Improved health check command for database services to support both `mysqladmin` and `mariadb-admin`.

 ### Caveats

The compatibility with PHP 8.4 is still pending due to errors in the integration-core dependency

```bash
magento-1  | Updating modules:
magento-1  | 
magento-1  | Deprecated Functionality: SeQura\Core\Infrastructure\Utility\TimeProvider::serializeDate(): Implicitly marking parameter $dateTime as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/sequra/integration-core/src/Infrastructure/Utility/TimeProvider.php on line 129
magento-1  | In ErrorHandler.php line 61:
magento-1  |                                                                                
magento-1  |   Deprecated Functionality: Sequra\Core\Helper\UrlHelper::getFrontendUrl(): I  
magento-1  |   mplicitly marking parameter $routeParams as nullable is deprecated, the exp  
magento-1  |   licit nullable type must be used instead in /var/www/html/vendor/sequra/mag  
magento-1  |   ento2-core/Helper/UrlHelper.php on line 77                                   
magento-1  |                                                                                
magento-1  | 
magento-1  | ❌ Magento 2 installation failed
```

 ### How is it tested?

Automatic tests

 ### How is it going to be deployed?

Standard deployment