### PR TITLE
Fix issues that occur during migration from version 2.6.3 to 2.7.0.

### DIFF
--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -85,6 +85,7 @@ class Version270 implements DataPatchInterface
 
             // Fetch all Sequra teasers from Magento 2 database and remove them
             $teasers = $this->fetchAllTeasersAndRemoveThem($connection);
+            $this->removeAllTeaserLayoutBlocks($connection);
             if (empty($teasers)) {
                 $connection->commit();
                 $this->moduleDataSetup->endSetup();
@@ -185,6 +186,35 @@ class Version270 implements DataPatchInterface
         $connection->delete($widgetInstance, ['instance_id IN (?)' => $ids]);
 
         return $teasers;
+    }
+
+    /**
+     * Removes all Sequra Teaser Layout Blocks from database
+     *
+     * @param AdapterInterface $connection
+     *
+     * @return void
+     */
+    private function removeAllTeaserLayoutBlocks(AdapterInterface $connection): void
+    {
+        $layoutUpdate = $this->moduleDataSetup->getTable('layout_update');
+        $query = $connection->select()->from($layoutUpdate)->where(
+            'xml LIKE ?',
+            '%Sequra_Core_Block_Widget_Teaser%',
+        );
+        $layoutBlocks = $connection->fetchAll($query);
+
+        if (empty($layoutBlocks)) {
+            return;
+        }
+
+        //Remove all Sequra layout blocks from database
+        $ids = [];
+        foreach ($layoutBlocks as $layoutBlock) {
+            $ids[] = $layoutBlock['layout_update_id'];
+        }
+
+        $connection->delete($layoutUpdate, ['layout_update_id IN (?)' => $ids]);
     }
 
     /**

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -30,7 +30,7 @@ use SeQura\Core\Infrastructure\ServiceRegister;
 class Version270 implements DataPatchInterface
 {
 
-    const WIDGET_STYLE_MAP= [
+    private const WIDGET_STYLE_MAP = [
         'L'        => '{"alignment":"left"}',
         'R'        => '{"alignment":"right"}',
         'legacy'   => '{"type":"legacy"}',
@@ -231,6 +231,13 @@ class Version270 implements DataPatchInterface
         $connection->delete($layoutUpdate, ['layout_update_id IN (?)' => $ids]);
     }
 
+    /**
+     * Returns mapped value for given theme value
+     *
+     * @param string $theme
+     *
+     * @return string
+     */
     private function getValidatedThemeJson(string $theme): string
     {
         $decoded = json_decode($theme, true);
@@ -239,7 +246,7 @@ class Version270 implements DataPatchInterface
             return $theme;
         }
 
-        if (array_key_exists($theme, self::WIDGET_STYLE_MAP) ) {
+        if (array_key_exists($theme, self::WIDGET_STYLE_MAP)) {
             return self::WIDGET_STYLE_MAP[$theme];
         }
 
@@ -384,7 +391,9 @@ class Version270 implements DataPatchInterface
 
         $paymentMethods = array_diff($paymentMethods, $updatedPaymentMethods);
         $newCustomWidgetSettings = $this->createCustomWidgetSettings($paymentMethods, $theme, $destinationSelector);
-        $widgetSettingsForProduct->setCustomWidgetsSettings(array_merge($customWidgetSettings, $newCustomWidgetSettings));
+        $widgetSettingsForProduct->setCustomWidgetsSettings(
+            array_merge($customWidgetSettings, $newCustomWidgetSettings)
+        );
 
         return $widgetSettingsForProduct;
     }

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -294,6 +294,7 @@ class Version270 implements DataPatchInterface
             if (is_array($teaserPaymentMethod)
                 && isset($teaserPaymentMethod['countryCode'], $teaserPaymentMethod['product'])
                 && in_array($teaserPaymentMethod['countryCode'], $availableCountries, true)
+                && !in_array($teaserPaymentMethod['product'], $paymentMethods, true)
             ) {
                 $paymentMethods[] = $teaserPaymentMethod['product'];
             }
@@ -382,8 +383,8 @@ class Version270 implements DataPatchInterface
         }
 
         $paymentMethods = array_diff($paymentMethods, $updatedPaymentMethods);
-        $customWidgetSettings = $this->createCustomWidgetSettings($paymentMethods, $theme, $destinationSelector);
-        $widgetSettingsForProduct->setCustomWidgetsSettings($customWidgetSettings);
+        $newCustomWidgetSettings = $this->createCustomWidgetSettings($paymentMethods, $theme, $destinationSelector);
+        $widgetSettingsForProduct->setCustomWidgetsSettings(array_merge($customWidgetSettings, $newCustomWidgetSettings));
 
         return $widgetSettingsForProduct;
     }

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -581,8 +581,7 @@ class Version270 implements DataPatchInterface
     {
         $disabledPaymentMethods = [];
         foreach ($availablePaymentMethods as $availablePaymentMethod) {
-            if (
-                !in_array($availablePaymentMethod->getProduct(), $paymentMethodsForMigration, true) &&
+            if (!in_array($availablePaymentMethod->getProduct(), $paymentMethodsForMigration, true) &&
                 in_array(
                     $availablePaymentMethod->getCategory(),
                     WidgetSettingsService::WIDGET_SUPPORTED_CATEGORIES_ON_PRODUCT_PAGE,

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -134,7 +134,7 @@ class Version270 implements DataPatchInterface
      *
      * @param AdapterInterface $connection
      *
-     * @return array<array<string, mixed>>
+     * @return array<string>
      */
     private function fetchAllTeasersAndRemoveThem(AdapterInterface $connection): array
     {
@@ -192,7 +192,7 @@ class Version270 implements DataPatchInterface
     /**
      * Migrates data from all Sequra teasers to new widget configurations.
      *
-     * @param mixed[] $teasers
+     * @param array<string> $teasers
      * @param array<WidgetSettingsEntity> $arrayOfWidgetSettingsEntities
      *
      * @return void
@@ -290,7 +290,7 @@ class Version270 implements DataPatchInterface
      *
      * @param array<string> $paymentMethods
      *
-     * @return array<array<string, mixed>>
+     * @return array<mixed>
      *
      * @throws JsonException
      */
@@ -518,7 +518,7 @@ class Version270 implements DataPatchInterface
     /**
      * Disables widgets for payment methods that were not configured prior to migration.
      *
-     * @param array<SeQuraPaymentMethod[]> $arrayOfAvailablePaymentMethodsPerStore
+     * @param array<string,SeQuraPaymentMethod> $arrayOfAvailablePaymentMethodsPerStore
      *
      * @return void
      * @throws RepositoryNotRegisteredException
@@ -572,10 +572,10 @@ class Version270 implements DataPatchInterface
     /**
      * Returns available payment methods on the product page, that were not configured prior to migration.
      *
-     * @param string[] $paymentMethodsForMigration
-     * @param SeQuraPaymentMethod[] $availablePaymentMethods
+     * @param array<string> $paymentMethodsForMigration
+     * @param array<SeQuraPaymentMethod> $availablePaymentMethods
      *
-     * @return array
+     * @return array<string>
      */
     private function getDisabledPaymentMethods(array $paymentMethodsForMigration, array $availablePaymentMethods): array
     {

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -92,7 +92,7 @@ class Version270 implements DataPatchInterface
             // Get available Sequra payment methods with new category property and cache them for every store
             foreach ($widgetSettingsEntities as $widgetSettingsEntity) {
                 $storeId = $widgetSettingsEntity->getStoreId();
-                /** @var SeQuraPaymentMethod $paymentMethods */
+                /** @var SeQuraPaymentMethod[] $paymentMethods */
                 $paymentMethods = StoreContext::doWithStore($storeId, function () {
                     return $this->getPaymentMethodsService()->getAvailablePaymentMethodsForAllMerchants(true);
                 });

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -33,14 +33,26 @@ class Version270 implements DataPatchInterface
 {
 
     private const WIDGET_STYLE_MAP = [
-        'L'        => '{"alignment":"left"}',
-        'R'        => '{"alignment":"right"}',
-        'legacy'   => '{"type":"legacy"}',
-        'legacyL'  => '{"type":"legacy","alignment":"left"}',
-        'legacyR'  => '{"type":"legacy","alignment":"right"}',
-        'minimal'  => '{"type":"text","branding":"none","size":"S","starting-text":"as-low-as"}',
-        'minimalL' => '{"type":"text","branding":"none","size":"S","starting-text":"as-low-as","alignment":"left"}',
-        'minimalR' => '{"type":"text","branding":"none","size":"S","starting-text":"as-low-as","alignment":"right"}'
+        'L'        => ['alignment' => 'left'],
+        'R'        => ['alignment' => 'right'],
+        'legacy'   => ['type' => 'legacy'],
+        'legacyL'  => ['type' => 'legacy', 'alignment' => 'left'],
+        'legacyR'  => ['type' => 'legacy', 'alignment' => 'right'],
+        'minimal'  => ['type' => 'text', 'branding' => 'none', 'size' => 'S', 'starting-text' => 'as-low-as'],
+        'minimalL' => [
+            'type' => 'text',
+            'branding' => 'none',
+            'size' => 'S',
+            'starting-text' => 'as-low-as',
+            'alignment' => 'left'
+        ],
+        'minimalR' => [
+            'type' => 'text',
+            'branding' => 'none',
+            'size' => 'S',
+            'starting-text' => 'as-low-as',
+            'alignment' => 'right'
+        ]
     ];
     /**
      * @var ModuleDataSetupInterface
@@ -279,7 +291,7 @@ class Version270 implements DataPatchInterface
         }
 
         if (array_key_exists($theme, self::WIDGET_STYLE_MAP)) {
-            return self::WIDGET_STYLE_MAP[$theme];
+            return json_encode(self::WIDGET_STYLE_MAP[$theme], JSON_THROW_ON_ERROR);
         }
 
         return '';

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -192,7 +192,7 @@ class Version270 implements DataPatchInterface
     /**
      * Migrates data from all Sequra teasers to new widget configurations.
      *
-     * @param array<array<string, mixed>> $teasers
+     * @param mixed[] $teasers
      * @param array<WidgetSettingsEntity> $arrayOfWidgetSettingsEntities
      *
      * @return void
@@ -312,7 +312,7 @@ class Version270 implements DataPatchInterface
      * @param string $priceSelector
      * @param string $destinationsSelector
      * @param string $theme
-     * @param array<array<string, mixed>> $teaserPaymentMethods
+     * @param mixed[] $teaserPaymentMethods
      * @param WidgetSettingsEntity $widgetSettingsEntity
      *
      * @return void

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -518,7 +518,7 @@ class Version270 implements DataPatchInterface
     /**
      * Disables widgets for payment methods that were not configured prior to migration.
      *
-     * @param array<string,SeQuraPaymentMethod> $arrayOfAvailablePaymentMethodsPerStore
+     * @param array<string,array<SeQuraPaymentMethod>> $arrayOfAvailablePaymentMethodsPerStore
      *
      * @return void
      * @throws RepositoryNotRegisteredException

--- a/Setup/Patch/Data/Version270.php
+++ b/Setup/Patch/Data/Version270.php
@@ -29,6 +29,17 @@ use SeQura\Core\Infrastructure\ServiceRegister;
  */
 class Version270 implements DataPatchInterface
 {
+
+    const WIDGET_STYLE_MAP= [
+        'L'        => '{"alignment":"left"}',
+        'R'        => '{"alignment":"right"}',
+        'legacy'   => '{"type":"legacy"}',
+        'legacyL'  => '{"type":"legacy","alignment":"left"}',
+        'legacyR'  => '{"type":"legacy","alignment":"right"}',
+        'minimal'  => '{"type":"text","branding":"none","size":"S","starting-text":"as-low-as"}',
+        'minimalL' => '{"type":"text","branding":"none","size":"S","starting-text":"as-low-as","alignment":"left"}',
+        'minimalR' => '{"type":"text","branding":"none","size":"S","starting-text":"as-low-as","alignment":"right"}'
+    ];
     /**
      * @var ModuleDataSetupInterface
      */
@@ -105,8 +116,11 @@ class Version270 implements DataPatchInterface
                 $priceSelector = $widgetParameters['price_sel'];
                 /** @var string $destinationSelector */
                 $destinationSelector = $widgetParameters['dest_sel'];
+
                 /** @var string $theme */
                 $theme = $widgetParameters['theme'];
+                $theme= $this->getValidatedThemeJson($theme);
+
                 /** @var array<string> $paymentMethods */
                 $paymentMethods = array_key_exists('payment_methods', $widgetParameters) ?
                     $widgetParameters['payment_methods'] : [];
@@ -215,6 +229,21 @@ class Version270 implements DataPatchInterface
         }
 
         $connection->delete($layoutUpdate, ['layout_update_id IN (?)' => $ids]);
+    }
+
+    private function getValidatedThemeJson(string $theme): string
+    {
+        $decoded = json_decode($theme, true);
+        $isJsonFormat = (json_last_error() === JSON_ERROR_NONE) && is_array($decoded);
+        if ($isJsonFormat) {
+            return $theme;
+        }
+
+        if (array_key_exists($theme, self::WIDGET_STYLE_MAP) ) {
+            return self::WIDGET_STYLE_MAP[$theme];
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
### What is the goal?
- Remove teaser layout blocks during migration
- Map widget styles correctly during migration
- Fix the issue with overridden custom payment method widget configuration
- Disable payment methods on product page if those methods were not configured in teasers before the migration

 ### References
* **Issue:** [LIS-76](https://sequra.atlassian.net/browse/LIS-76)

 ### How is it being implemented?

- Updated migration to remove all Sequra teaser layout blocks from the Magento database
- Added mapping for widget styles to ensure they are correctly migrated
- Updated migration to prevent only the last custom payment method widget configuration from being saved
- Updated migration to add custom widget styles with disabled payment methods for every store if those methods were not configured in teasers before the migration

 ### How is it tested?

- Manual tests
  - Install SeQura Magento 2 module version 2.6.3
  - Set up the module and enable widgets on the product page
  - Configure Magento widgets
  - Add layout blocks to Magento widgets
  - Set different theme values for different widgets
  - Go to the storefront and verify widgets on the product page
  - Update the module to version 2.7.0
  - Go to the storefront and verify widgets on the product page
  - Go to the module settings and verify migrated configuration

[LIS-76]: https://sequra.atlassian.net/browse/LIS-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ