### PR TITLE
Update integration-core requirement to version 2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.4 <8.4",
-        "sequra/integration-core": "^2.1",
+        "sequra/integration-core": "v2.1.0",
         "ext-json": "*"
     },
     "autoload": {


### PR DESCRIPTION
 ### What is the goal?

Update integration-core requirement to version 2.1.0

 ### How is it being implemented?

This pull request updates the dependency versioning in the `composer.json` file to ensure more precise control over the `sequra/integration-core` package.

Dependency updates:

* Changed the version constraint for `sequra/integration-core` from `^2.1` to `v2.1.0` in `composer.json`. This ensures that the project explicitly uses version `2.1.0` instead of allowing any compatible `2.x` version.

 ### How is it tested?

Automatic tests

 ### How is it going to be deployed?

Standard deployment
