### PR TITLE
Add support for PHP 8.4

### DIFF
--- a/Block/Adminhtml/Configuration/Index.php
+++ b/Block/Adminhtml/Configuration/Index.php
@@ -54,7 +54,7 @@ class Index extends Template
         string $controllerName,
         string $storeId,
         string $action,
-        string $identifier = null
+        ?string $identifier = null
     ): string {
         $routeParams = [
             'storeId' => $storeId,

--- a/Helper/UrlHelper.php
+++ b/Helper/UrlHelper.php
@@ -77,7 +77,7 @@ class UrlHelper
      *
      * @throws NoSuchEntityException
      */
-    public function getFrontendUrl(string $routePath, array $routeParams = null): string
+    public function getFrontendUrl(string $routePath, ?array $routeParams = null): string
     {
         $storeView = $this->storeManager->getStore();
         $url = $this->urlHelper->setScope($storeView)->getUrl($routePath, $routeParams);
@@ -98,7 +98,7 @@ class UrlHelper
      *
      * @return string Publicly visible URL of the requested back-end controller.
      */
-    public function getBackendUrl(string $routePath, array $routeParams = null): string
+    public function getBackendUrl(string $routePath, ?array $routeParams = null): string
     {
         return $this->backendUrlHelper->getUrl($routePath, $routeParams);
     }

--- a/Repository/BaseRepository.php
+++ b/Repository/BaseRepository.php
@@ -86,14 +86,14 @@ class BaseRepository implements RepositoryInterface
     /**
      * Executes select query.
      *
-     * @param QueryFilter $filter Filter for query.
+     * @param QueryFilter|null $filter Filter for query.
      *
      * @return Entity[] A list of found entities ot empty array.
      *
      * @throws QueryFilterInvalidParamException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function select(QueryFilter $filter = null)
+    public function select(?QueryFilter $filter = null)
     {
         /** @var Entity $entity */
         $entity = new $this->entityClass;
@@ -105,14 +105,14 @@ class BaseRepository implements RepositoryInterface
     /**
      * Executes select query and returns first result.
      *
-     * @param QueryFilter $filter Filter for query.
+     * @param QueryFilter|null $filter Filter for query.
      *
      * @return Entity|null First found entity or NULL.
      *
      * @throws QueryFilterInvalidParamException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function selectOne(QueryFilter $filter = null)
+    public function selectOne(?QueryFilter $filter = null)
     {
         if ($filter === null) {
             $filter = new QueryFilter();
@@ -173,14 +173,14 @@ class BaseRepository implements RepositoryInterface
     /**
      * Counts records that match filter criteria.
      *
-     * @param QueryFilter $filter Filter for query.
+     * @param QueryFilter|null $filter Filter for query.
      *
      * @return int Number of records that match filter criteria.
      *
      * @throws QueryFilterInvalidParamException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function count(QueryFilter $filter = null)
+    public function count(?QueryFilter $filter = null)
     {
         return count($this->select($filter));
     }

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4 <8.4",
-        "sequra/integration-core": "v2.2.0",
+        "php": ">=7.4",
+        "sequra/integration-core": "dev-feature/support-php8.4",
         "ext-json": "*"
     },
     "autoload": {
@@ -60,7 +60,7 @@
         ]
     },
     "require-dev": {
-        "magento/magento-coding-standard": "^33.0"
+        "magento/magento-coding-standard": "^38.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbf08a9470fd3033cbd7bb8ffdce3321",
+    "content-hash": "c96018557edb74b49775adaca43168bb",
     "packages": [
         {
             "name": "sequra/integration-core",
-            "version": "dev-feature/LIS-74",
+            "version": "dev-feature/support-php8.4",
             "source": {
                 "type": "git",
                 "url": "git@github.com:sequra/integration-core.git",
-                "reference": "4b69a44d4013ed730ef1d9e820c7bf64ad5840b1"
+                "reference": "e134b9e1c7ea365cc8a3fd94d7d599b75f3a092f"
             },
             "require": {
                 "ext-ctype": "*",
@@ -22,7 +22,7 @@
             },
             "require-dev": {
                 "phpcompatibility/php-compatibility": "*",
-                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan": "^1.12 || ^2.1",
                 "phpunit/phpunit": "8.5.14"
             },
             "type": "library",
@@ -43,34 +43,34 @@
                 "proprietary"
             ],
             "description": "Core SeQura integration library",
-            "time": "2025-07-28T14:15:03+00:00"
+            "time": "2025-08-05T15:16:16+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -90,9 +90,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -100,7 +100,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -121,31 +120,50 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "magento/magento-coding-standard",
-            "version": "33",
+            "version": "38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/magento-coding-standard.git",
-                "reference": "75215870d446f955ea08acdad9badff647117cfa"
+                "reference": "159cb6b966e7a464a41973e4a2daec2374bf4a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/magento-coding-standard/zipball/75215870d446f955ea08acdad9badff647117cfa",
-                "reference": "75215870d446f955ea08acdad9badff647117cfa",
+                "url": "https://api.github.com/repos/magento/magento-coding-standard/zipball/159cb6b966e7a464a41973e4a2daec2374bf4a02",
+                "reference": "159cb6b966e7a464a41973e4a2daec2374bf4a02",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-simplexml": "*",
                 "magento/php-compatibility-fork": "^0.1",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "phpcsstandards/phpcsutils": "^1.0.5",
-                "rector/rector": "^0.17.12",
+                "rector/rector": "^1.2.4",
                 "squizlabs/php_codesniffer": "^3.6.1",
                 "webonyx/graphql-php": "^15.0"
             },
@@ -171,9 +189,9 @@
             "description": "A set of Magento specific PHP CodeSniffer rules.",
             "support": {
                 "issues": "https://github.com/magento/magento-coding-standard/issues",
-                "source": "https://github.com/magento/magento-coding-standard/tree/v33"
+                "source": "https://github.com/magento/magento-coding-standard/tree/v38"
             },
-            "time": "2023-12-19T17:16:36+00:00"
+            "time": "2025-06-09T14:09:34+00:00"
         },
         {
             "name": "magento/php-compatibility-fork",
@@ -339,16 +357,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.27",
+            "version": "1.12.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162"
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a6e423c076ab39dfedc307e2ac627ef579db162",
-                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
                 "shasum": ""
             },
             "require": {
@@ -393,31 +411,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-21T20:51:45+00:00"
+            "time": "2025-07-17T17:15:39+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "0.17.13",
+            "version": "1.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "e2003ba7c5bda06d7bb419cf4be8dae5f8672132"
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e2003ba7c5bda06d7bb419cf4be8dae5f8672132",
-                "reference": "e2003ba7c5bda06d7bb419cf4be8dae5f8672132",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40f9cf38c05296bd32f444121336a521a293fa61",
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.10.26"
+                "phpstan/phpstan": "^1.12.5"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
                 "rector/rector-downgrade-php": "*",
                 "rector/rector-phpunit": "*",
                 "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
             },
             "bin": [
                 "bin/rector"
@@ -441,7 +462,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.17.13"
+                "source": "https://github.com/rectorphp/rector/tree/1.2.10"
             },
             "funding": [
                 {
@@ -449,7 +470,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-14T16:33:29+00:00"
+            "time": "2024-11-08T13:59:10+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -537,16 +558,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.20.0",
+            "version": "v15.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "60feb7ad5023c0ef411efbdf9792d3df5812e28f"
+                "reference": "d160c99334edd34adbc38fbe80b6df455d1923f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/60feb7ad5023c0ef411efbdf9792d3df5812e28f",
-                "reference": "60feb7ad5023c0ef411efbdf9792d3df5812e28f",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d160c99334edd34adbc38fbe80b6df455d1923f8",
+                "reference": "d160c99334edd34adbc38fbe80b6df455d1923f8",
                 "shasum": ""
             },
             "require": {
@@ -559,14 +580,14 @@
                 "amphp/http-server": "^2.1",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.73.1",
+                "friendsofphp/php-cs-fixer": "3.84.0",
                 "mll-lab/php-cs-fixer-config": "5.11.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "2.1.8",
-                "phpstan/phpstan-phpunit": "2.0.4",
-                "phpstan/phpstan-strict-rules": "2.0.4",
+                "phpstan/phpstan": "2.1.20",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "2.0.6",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
                 "psr/http-message": "^1 || ^2",
                 "react/http": "^1.6",
@@ -599,7 +620,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.20.0"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.22.0"
             },
             "funding": [
                 {
@@ -607,7 +628,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-03-21T08:45:04+00:00"
+            "time": "2025-07-28T12:28:41+00:00"
         }
     ],
     "aliases": [],
@@ -618,9 +639,9 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4 <8.4",
+        "php": ">=7.4",
         "ext-json": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### What is the goal?

- Add support for PHP 8.4

 ### References
* **Issue:** [LIS-80](https://sequra.atlassian.net/browse/LIS-80)

 ### How is it being implemented?

- Updated composer.json to support PHP 8.4
- Updated Magento coding standard package version in composer.json to support PHP 8.4
- Updated classes by explicitly specifying nullable input parameters in methods

 ### How is it tested?
- Run command to check PHP syntax
- Manual tests
   - Install the SeQura module in the Magento 2 system
   - Connect the integration
   - Setup configurations
   - Setup widgets
   - Setup both deployments
   - Go to storefront
   - Verified widgets
   - Verified payment process

[LIS-80]: https://sequra.atlassian.net/browse/LIS-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ