### PR TITLE
Fix issue with widget initializer when widget configuration is missing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.4",
-        "sequra/integration-core": "v2.3.0",
+        "sequra/integration-core": "dev-fix/LIS-85",
         "ext-json": "*"
     },
     "autoload": {


### PR DESCRIPTION
### What is the goal?

- Add a check to see if a widget configuration exists for the current store when the widget initializer is called, and if it doesn’t exist, do not load the widget data.

 ### References
* **Issue:** [LIS-85](https://sequra.atlassian.net/browse/LIS-85)

 ### How is it being implemented?

- Updated CORE version

### How is it tested?
- Manual tests
   - Setup multiple store views in Magento 2 system
   - Install the SeQura module
   - Connect the integration in one store view
   - Setup configurations
   - Setup widgets
   - Go to storefront on store view that is not connected with SeQura
   - Verified product page
   - Verified cart page
   - Verified checkoutpage
  
[LIS-85]: https://sequra.atlassian.net/browse/LIS-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ