### PR TITLE
Update sequra/integration-core version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.4",
-        "sequra/integration-core": "dev-fix/LIS-84",
+        "sequra/integration-core": "~2.4.0",
         "ext-json": "*"
     },
     "autoload": {
@@ -74,3 +74,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
### What is the goal?

Fix the reference to the Integration Core version

 ### How is it being implemented?

This pull request updates the `composer.json` file to use a stable version of the `sequra/integration-core` dependency instead of an inexistent development branch.

Dependency management:

* Updated the `sequra/integration-core` dependency from the development branch `dev-fix/LIS-84` to the stable version `~2.4.0` in `composer.json`.

 ### How is it tested?

Automatic tests

 ### How is it going to be deployed?

Standard deployment
