### PR TITLE
Do not display payment methods widget info link when widget configuration is disabled

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/sequra-payment.js
@@ -306,5 +306,9 @@ define([
         showLogo: function () {
             return window.checkoutConfig.payment.sequra_payment.showlogo;
         },
+
+        isSequraObjectAvailable: function () {
+            return (typeof Sequra !== 'undefined' && typeof Sequra.refreshComponents === 'function');
+        },
     });
 });

--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -55,7 +55,7 @@
                     enable: ($parent.getCode() == $parent.isChecked()),
                     css: {
                         disabled: !$parent.isPlaceOrderActionAllowed(),
-                        ['sequra_' + product]: typeof product !== 'undefined' && product
+                        ['sequra_' + product]: product
                     }
                     "
                         disabled>

--- a/view/frontend/web/template/payment/form.html
+++ b/view/frontend/web/template/payment/form.html
@@ -1,6 +1,8 @@
 <!-- ko foreach: sequraPaymentMethods -->
 <div class="payment-method" data-bind="css: {'_active': (product == $parent.getSelectedProduct())},
-                    afterRender: Sequra.refreshComponents">
+                    afterRender: typeof Sequra !== 'undefined' && Sequra.refreshComponents
+                             ? Sequra.refreshComponents
+                             : function() {}">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"
@@ -14,7 +16,7 @@
             <!-- ko if: cost_description -->
             <span class="sequra_partpayment_cost_description" data-bind="text: cost_description"></span>
             <!--/ko-->
-            &nbsp;
+            <!-- ko if: $parent.isSequraObjectAvailable() -->
             <span class="sequra-educational-popup" style="z-index: 1;"
                   data-bind="
                     attr: {
@@ -23,6 +25,7 @@
                         'data-campaign': campaign
                     }
                 "> + info</span>
+            <!--/ko-->
         </label>
     </div>
 
@@ -52,7 +55,7 @@
                     enable: ($parent.getCode() == $parent.isChecked()),
                     css: {
                         disabled: !$parent.isPlaceOrderActionAllowed(),
-                        ['sequra_' + product]: true
+                        ['sequra_' + product]: typeof product !== 'undefined' && product
                     }
                     "
                         disabled>


### PR DESCRIPTION
### What is the goal?

- Do not display info link for the pop-up widget on the payment method, when the widget configuration is disabled

 ### References
* **Issue:** [LIS-82](https://sequra.atlassian.net/browse/LIS-82)

 ### How is it being implemented?

- Updated JS file to check if the Sequra object is defined
- Updated template to verify conditions before displaying the info link
- Updated template to check if the Sequra object is defined and refresh components only when it is

 ### How is it tested?
- Run command to check PHP syntax
- Manual tests
   - Install the SeQura module in the Magento 2 system
   - Test classic checkout payment flow when Widget Settings are enabled 
   - Test classic checkout payment flow when Widget Settings are disabled
   - Install the OneStepCheckout module and enable it
   - Test OneStepCheckout checkout payment flow when Widget Settings are enabled
   - Test OneStepCheckout checkout payment flow when Widget Settings are disabled

[LIS-82]: https://sequra.atlassian.net/browse/LIS-82