### PR TITLE
[PAR-765] Rename Version400 migration patch to Version321 and bump version to 3.2.1

### DIFF
--- a/Setup/Patch/Data/Version321.php
+++ b/Setup/Patch/Data/Version321.php
@@ -8,7 +8,7 @@ use SeQura\Core\BusinessLogic\Domain\Migration\Tasks\StoreIntegrationMigrateTask
 use SeQura\Core\Infrastructure\Logger\Logger;
 use Throwable;
 
-class Version400 implements DataPatchInterface
+class Version321 implements DataPatchInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -52,7 +52,7 @@ class Version400 implements DataPatchInterface
 
             Logger::logInfo('Migration ' . self::class . ' has been successfully finished.');
         } catch (Throwable $e) {
-            Logger::logError('Update script V4.0.0 execution failed because: ' . $e->getMessage());
+            Logger::logError('Update script V3.2.1 execution failed because: ' . $e->getMessage());
         }
 
         $this->moduleDataSetup->endSetup();

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "pagos",
         "magento2"
     ],
-    "version": "3.2.0",
+    "version": "3.2.1",
     "license": "MIT",
     "authors": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sequra_Core" setup_version="3.2.0">
+    <module name="Sequra_Core" setup_version="3.2.1">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
 ### What is the goal?

The StoreIntegrationMigrateTask was mistakenly placed in a Version400 patch class during the 3.2.0 release, causing it to not execute.

 ### References
* **Issue:** PAR-765

 ### How is it being implemented?

Renamed the class to Version321 so Magento picks it up correctly for the 3.2.1 upgrade path.

- Renamed Setup/Patch/Data/Version400.php → Version321.php
- Updated class name from Version400 to Version321
- Updated error log message to reference V3.2.1
- Bumped setup_version in etc/module.xml from 3.2.0 to 3.2.1
- Bumped version in composer.json from 3.2.0 to 3.2.1

 ### How is it tested?

Manual tests

 ### How is it going to be deployed?

Standard deployment