### PR TITLE
fix: URL-encode ';' in Google Fonts @import to survive CSS merge (admin SeQura page unstyled)

### DIFF
--- a/view/adminhtml/web/css/sequra-core.css
+++ b/view/adminhtml/web/css/sequra-core.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900%3B1,14..32,100..900&display=swap");
 #sequra-page {
   margin: 0;
   padding: 0;

--- a/view/adminhtml/web/css/sequra-core.css
+++ b/view/adminhtml/web/css/sequra-core.css
@@ -1,4 +1,8 @@
 @charset "UTF-8";
+/* Keep ';' URL-encoded as %3B: some CSS aggregators (e.g. Magento's
+   CssResolver::aggregateImportDirectives non-greedy `@import\s.+?;` regex)
+   terminate the @import at the first literal ';' inside the URL,
+   truncating it mid-string and breaking the merged stylesheet. */
 @import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900%3B1,14..32,100..900&display=swap");
 #sequra-page {
   margin: 0;


### PR DESCRIPTION
Fixes #112

## Summary

URL-encodes the `;` as `%3B` in the Google Fonts `@import` URL of `view/adminhtml/web/css/sequra-core.css` so that Magento's CSS aggregator (`Magento\Framework\View\Url\CssResolver::aggregateImportDirectives`) doesn't truncate the URL when `dev/css/merge_css_files=1`.

Google Fonts decodes `%3B` identically server-side — the returned font CSS is unchanged.

## Why

The current `@import` URL contains a literal `;` between the two font-axis tuples of the Inter variable font (post-2024 Google Fonts multi-tuple syntax). Magento's aggregator uses a non-greedy regex (`@import\s.+?;`) that stops at the first `;` it encounters, with no awareness of quoted URL strings. The merged CSS ends up with an unterminated `@import url("..."` statement, which causes the browser's CSS parser to drop every subsequent rule. The admin "SeQura Configuration" page then renders completely unstyled (`document.styleSheets[0].cssRules.length === 0`).

Full root-cause analysis and reproduction steps are in the linked issue.

## The change

```diff
--- a/view/adminhtml/web/css/sequra-core.css
+++ b/view/adminhtml/web/css/sequra-core.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900%3B1,14..32,100..900&display=swap");
 #sequra-page {
   margin: 0;
   padding: 0;
```

One line. The CSS is byte-identical to what Google Fonts returns either way.

## Validation

Validated on a freshly-installed Magento 2.4.7-p9 vanilla (no Hyvä, no third-party modules) with `sequra/magento2-core` from this branch + `dev/css/merge_css_files=1`:

| Metric | Before (master) | After (this PR) |
|---|---:|---:|
| `document.styleSheets[0].cssRules.length` | 0 | **6817** |
| First-line `@import` URL closes properly | ❌ | ✅ |
| `#sequra-page` y-position | 750 px | -0.4 px (top of viewport) |
| Document height | 3025 px | 1212 px |
| Admin page renders | ❌ unstyled | ✅ full UI |
| JS errors in console | 0 | 0 |

Re-tested the inverse: reverting this commit on master + `merge=1` reproduces the bug. So the fix is necessary and sufficient.

## Alternative considered

A cleaner long-term option is to move the `@import` out of the CSS file and into the layout XML as a `<css src="..." src_type="url"/>` — external URLs declared that way bypass Magento's CSS merge entirely. That requires more code surface (touching `sequra_configuration_index.xml` and removing the `@import` from `sequra-core.css`) and a layout-handle change. Happy to open a follow-up PR with that approach if preferred, but this 1-line fix unblocks affected merchants today with zero risk.

## Risk

Minimal. The change is one character substitution in a URL query string. `%3B` is the canonical URL-encoding of `;` per RFC 3986, and Google Fonts has decoded it identically for years (verified by fetching both URLs and `diff`-ing the response bodies — they match byte-for-byte).
