### PR TITLE
fix: bump version to 3.2.2 to match git tag for Packagist sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "pagos",
         "magento2"
     ],
-    "version": "3.2.1",
+    "version": "3.2.2",
     "license": "MIT",
     "authors": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -5,7 +5,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Sequra_Core" setup_version="3.2.1">
+    <module name="Sequra_Core" setup_version="3.2.2">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_ConfigurableProduct"/>


### PR DESCRIPTION
### What is the goal?

Fix the failed Packagist tag sync. The sync skipped tag `3.2.2` with:

```
[2026-06-08T10:09:30.904+00:00] Skipped tag 3.2.2, tag (3.2.2.0) does not match version (3.2.1.0) in composer.json
```

The `3.2.2` git tag was created while `composer.json` still declared `3.2.1`, so Packagist rejected the release.

### How is it being implemented?

* Bump `version` in `composer.json` from `3.2.1` to `3.2.2`.
* Bump `setup_version` in `etc/module.xml` from `3.2.1` to `3.2.2` to keep it in sync.

These are the only two version declarations in the module.

### How is it tested?

Automated tests. Version-only change; verified `composer.json` and `etc/module.xml` are the only files declaring the module version.

### How is it going to be deployed?

- [ ] Merge to `master`
- [ ] Re-point the `3.2.2` tag to the merge commit
- [ ] Verify Packagist picks up the release