### PR TITLE
[PAR-805] Add Claude configuration and capability definitions

### DIFF
--- a/.claude/docs/codingStandard.md
+++ b/.claude/docs/codingStandard.md
@@ -1,0 +1,177 @@
+# Coding Standard
+
+Conventions for **`Sequra_Core`** — the Magento 2 module that bridges Magento's
+payment framework with the platform-agnostic `sequra/integration-core` library.
+Unlike the core library, this is **Magento-specific code**: it uses Magento DI,
+Blocks/Controllers/Plugins/Observers/Gateway, and consumes integration-core
+through its facades and `Domain/Integration` interfaces.
+
+> This is the authoritative standard for **this module**. The integration-core
+> standard (`integration-core/.claude/docs/codingStandard.md`) governs the
+> library; where the two differ (PHP floor, PHPStan level, DI mechanism, allowed
+> language features) **this file wins for `Sequra_Core`**.
+
+## 0. The quality gate (non-negotiable)
+
+CI (`.github/workflows/static-analysis.yml`) runs, in this order — and a PR is
+not done until all pass:
+
+1. **PHP syntax** on **7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5** (`php -l`).
+2. **PHPCS** — `./bin/phpcs -q` (Magento2 coding standard + PHPCompatibility, `.phpcs.xml.dist`).
+3. **PHPStan** — `./bin/update-sequra` then `./bin/phpstan` (**level 9**, `phpstan.neon`).
+
+So the rule is: **`phpcs` → `phpstan` must both pass** (after the syntax sweep).
+Fix style first (`./bin/phpcbf` auto-fixes most), then resolve every phpstan
+finding — **don't silence the analyser**; the only sanctioned ignores are for
+Magento's auto-generated factories (see §5).
+
+**All dev tools run inside Docker via the `bin/` wrappers — never run
+phpcs/phpstan/composer directly on the host.** Common commands:
+
+```bash
+./bin/phpcs -q            # check style
+./bin/phpcbf              # auto-fix style
+./bin/update-sequra       # reinstall the module into Magento's vendor (do before phpstan)
+./bin/phpstan             # static analysis, level 9
+```
+
+## 1. Architecture
+
+`Sequra_Core` is a standard Magento 2 module. Source lives under PSR-4 root
+`Sequra\Core\` (maps to the repo root). Layers/areas:
+
+| Area | Location | Notes |
+|------|----------|-------|
+| Payment gateway components | `Gateway/` | Magento Payment Gateway framework (capture/refund/void) |
+| Storefront/admin controllers | `Controller/` | `Adminhtml/` (custom admin UI), `ExpressCheckout/`, webhook/comeback |
+| REST endpoints | `etc/webapi.xml` + `Api/` (interfaces) + `Model/Api/` (impl) | |
+| Blocks / view models | `Block/` | + `view/frontend|adminhtml/templates/*.phtml` |
+| Plugins (interceptors) | `Plugin/` | e.g. `CsrfValidator`, `MiniWidgets` |
+| Observers | `Observer/` (wired in `etc/events.xml`) | |
+| Models / persistence | `Model/`, `etc/db_schema.xml` | tables `sequra_entity`, `sequra_queue`, `sequra_order` |
+| DI wiring | `etc/di.xml`, `etc/frontend/di.xml` | virtual types, preferences, plugins |
+| **integration-core bridge** | `Services/Bootstrap.php` | registers ~20 core service implementations |
+
+## 2. Consuming integration-core (don't fork it)
+
+This module is a **consumer** of `sequra/integration-core`. Never edit the
+library from here.
+
+- **Call business logic through the core facades** — `CheckoutAPI::get()->…`,
+  `AdminAPI::get()->…` — which return a `Response` (`isSuccessful()` + `toArray()`).
+  Treat an unsuccessful response as the failure path; don't expect exceptions.
+- **Provide platform capabilities by implementing `Domain/Integration/*Interface`**
+  in `Services/` (e.g. product/category/order/store services) and **registering
+  them in `Services/Bootstrap.php`** (which extends the core `BootstrapComponent`).
+  When the core needs new shop data, the contract is added there — not invented here.
+- Keep Magento types out of arguments passed into the core; map to the core's
+  request DTOs at the boundary (controllers / `Model/Api/`).
+
+## 3. PHP language floor (7.4)
+
+The module targets **PHP 7.4 → 8.5** (`composer.json: ">=7.4 <8.6"`, CI syntax
+sweep 7.4–8.5). Code must parse on **7.4** and on **8.5**:
+
+- ✅ **Typed properties** (`private RawFactory $resultRawFactory;`), arrow
+  functions, `??=`, array spread — all 7.4, use them.
+- ✅ Nullable/scalar type hints, `void`/`self` returns.
+- ❌ **8.0+ features are off-limits**: constructor property promotion, union
+  types, named arguments, `match`, nullsafe `?->`, attributes; ❌ **8.1+**:
+  `enum`, `readonly`, first-class callable syntax, `never`.
+- Express closed sets as class constants or small value objects, not `enum`.
+
+(This is the key divergence from integration-core, whose floor is 7.2 and which
+therefore forbids typed properties — here they are expected.)
+
+## 4. Dependency injection (Magento)
+
+- **Constructor injection only**, resolved by Magento's ObjectManager from
+  `etc/di.xml`. Don't call `ObjectManager` directly; don't `new` services.
+- Depend on **interfaces / `…Interface`** where one exists; use **virtual types**
+  and `<preference>` in `di.xml` for configuration (e.g. the gateway facade).
+- **Factories**: Magento auto-generates `<Class>Factory`. Inject and use them
+  (`$this->fooFactory->create()`) for non-shared/data objects. These generated
+  classes are invisible to PHPStan — see §5.
+- A new injected dependency only needs the constructor param; framework-built
+  classes (Blocks, Controllers) need no manual wiring.
+
+## 5. PHPStan (level 9) — the Magento gotchas
+
+Level 9 is strict about `mixed`. The recurring patterns in this codebase:
+
+- **Auto-generated factories → ignore in `phpstan.neon`.** PHPStan can't see
+  generated `*Factory` classes, so add the class to the `ignoreErrors` block
+  (the established convention — `OrderFactory`, `RawFactory`, `QuoteFactory`,
+  `CreateOrderRequestBuilderFactory`, …). Add **both** message shapes when hit:
+  `#unknown class …\\FooFactory#i` and `#invalid type …\\FooFactory#i`. This is
+  the **only** sanctioned use of `ignoreErrors`.
+- **Magento getters return `mixed` — never blind-cast.** `$model->getId()`,
+  `getTypeId()`, `DeploymentConfig::get()`, request `getParam()` are `mixed`
+  (or `array|string`). Casting `(string)$mixed` fails level 9 — **narrow first**:
+  `is_scalar($x) ? (string)$x : ''` / `is_string($x) ? $x : ''`.
+- **Magic setters/getters are "undefined" to PHPStan.** `$quote->setTotalsCollectedFlag(false)`
+  isn't a real method → use the real `$quote->setData('totals_collected_flag', false)`
+  (and `getData(...)` to read). Prefer the concrete-method API when one genuinely exists.
+- **Respect interface arity.** A `Data` interface may declare fewer params than
+  the model (`OrderPaymentInterface::getAdditionalInformation()` takes 0 args) —
+  call it as the interface declares and index the returned array.
+- Prefer a **structural fix** over an ignore: e.g. pass a typed `array` instead of
+  re-parsing a query string, or use `getParams(): array` instead of `getQuery()` (`mixed`).
+
+## 6. PHPCS (Magento2 standard) — the recurring rules
+
+- **Docblock short description must be a single line** (Magento2.Annotation):
+  one-line summary, blank `*` line, then the long description.
+- **Every parameter needs an `@param`**, and the type must parse — the generic
+  `array<string, mixed>` form can trip the sniff; use `mixed[]` (or `Type[]`).
+- **Public methods need full docblocks** (`@param`/`@return`/`@throws`).
+- **Line length ≤ 120**; extract a variable rather than wrapping a PHP expression
+  inside a `.phtml` attribute.
+- **Discouraged functions** (e.g. `parse_str`, `extract`): avoid them — refactor
+  so they're unnecessary; only as a last resort add a justified, single-line
+  `// phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged` directly
+  above the call.
+- Run `./bin/phpcbf` to auto-fix spacing/indent/EOL before hand-fixing.
+
+## 7. Type safety & docblocks
+
+- Type hints on every param/return that 7.4 allows; document array shapes
+  (`@param mixed[] $x`, `@return array<string, mixed>`) — never a bare `array`.
+- `@throws` lists every propagated exception.
+- A class docblock (1–3 lines) on every class; `@inheritDoc` is fine on overrides.
+
+## 8. Storefront controllers, blocks & templates
+
+- **Controllers** implement the specific action interface
+  (`HttpGetActionInterface` / `HttpPostActionInterface`) — never both; this
+  restricts the HTTP method.
+- Returning raw HTML/JSON uses `RawFactory`/`ResultFactory`; set explicit
+  `Cache-Control: no-store` on per-session/stateful responses so they're never
+  full-page cached.
+- **CSRF**: storefront POST controllers are CSRF-validated by default;
+  exemptions live in `Plugin/Framework/App/Request/CsrfValidator.php` (kept as
+  narrow as possible).
+- **Templates (`.phtml`)**: always escape output via `$escaper->escapeHtml*()` /
+  `$block->escapeHtml()` — unescaped output trips `Magento2.Security.XssTemplate`.
+  Keep logic out of templates; compute in the Block/ViewModel.
+
+## 9. General style
+
+- KISS / DRY / YAGNI; one class per file; `Interface` suffix, `Abstract` prefix.
+- Verb-noun methods (`getSolicitUrl`, `solicit`); booleans `is/has/should/can`.
+- Class constants for magic strings/numbers; no globals.
+- **Stage new source files immediately** — when you add a PHP/JS/XML source file,
+  `git add` it the same change so it isn't left untracked (ad-hoc scratch `*.md`
+  in the repo root are exempt).
+- Match the surrounding code's formatting; `./bin/phpcbf` settles disputes.
+
+## 10. Checklist for a new class / feature
+
+- [ ] Placed in the correct module area (§1); platform capabilities go through a
+      `Domain/Integration` interface implemented in `Services/`, not ad-hoc calls (§2).
+- [ ] PHP **7.4**-safe syntax (§3); typed properties OK, no 8.0+ syntax.
+- [ ] DI via constructor + `di.xml`; new generated factories added to `phpstan.neon` ignores (§5).
+- [ ] `mixed`/magic-method access narrowed or routed through `setData/getData` (§5).
+- [ ] Full docblocks, single-line short description, `mixed[]` array types (§6).
+- [ ] `.phtml` output escaped (§8); new source files `git add`-ed (§9).
+- [ ] Green end-to-end: **`./bin/phpcs -q` → `./bin/update-sequra` → `./bin/phpstan`**, all on PHP 7.4–8.5.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,14 +21,14 @@
       "Bash(git show:*)",
       "Bash(git branch:*)",
       "Bash(git --version)",
-      "Bash(git check-attr *)",
+      "Bash(git check-attr:*)",
       "Skill(sq-git:commit)",
       "Skill(sq-git:open-pr)",
       "Skill(sq-git:sync-branch)"
     ],
     "deny": [
-      "Read(.env)",
-      "Read(.env.*)",
+      "Read(**/.env*)",
+      "Read(.env*)",
       "Read(**/*.pem)",
       "Read(**/*.key)"
     ],

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bin/phpcs:*)",
+      "Bash(bin/phpcbf:*)",
+      "Bash(bin/phpstan:*)",
+      "Bash(bin/magento:*)",
+      "Bash(bin/composer:*)",
+      "Bash(bin/n98-magerun2:*)",
+      "Bash(bin/npm:*)",
+      "Bash(bin/install-hyva:*)",
+      "Bash(bin/playwright:*)",
+      "Bash(bin/update-sequra:*)",
+      "Bash(bin/update-integration-core-ui:*)",
+      "Bash(bin/xdebug:*)",
+      "Bash(php -l:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git --version)",
+      "Bash(git check-attr *)",
+      "Skill(sq-git:commit)",
+      "Skill(sq-git:open-pr)",
+      "Skill(sq-git:sync-branch)"
+    ],
+    "deny": [
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)"
+    ],
+    "ask": [
+      "Bash(./setup.sh:*)",
+      "Bash(./teardown.sh:*)",
+      "Bash(git push:*)"
+    ]
+  }
+}

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: version-bump
+description: Bump the Sequra_Core module version safely across all the places that must stay in lockstep — composer.json "version", etc/module.xml setup_version, and (only when a data migration is needed) a new Setup/Patch/Data/Version*.php patch — plus a reminder that the git tag must match. Use when releasing or preparing a new module version (e.g. "bump to 3.3.1", "prepare the 3.4.0 release").
+---
+
+# Bump the Sequra_Core module version
+
+The version lives in **three** coupled places and a desync has shipped before
+(commit `12f117c` — *"fix: bump version to 3.2.2 to match git tag"*). This skill
+changes them together so nothing drifts.
+
+The three coupled values:
+1. `composer.json` → `"version": "X.Y.Z"`
+2. `etc/module.xml` → `<module name="Sequra_Core" setup_version="X.Y.Z">`
+3. The **git tag** `X.Y.Z` (created at release time — this skill does NOT tag; it
+   only ensures the files will match the tag you cut).
+
+A `Setup/Patch/Data/Version*.php` patch is added **only when the bump needs a data
+migration** — most bumps don't (e.g. `3.2.2` shipped without one).
+
+## Before you start
+
+1. Get the target version `X.Y.Z` (semver). Confirm it's strictly greater than the
+   current value in `composer.json` / `etc/module.xml`.
+2. Read the current values so you know what you're replacing:
+   - `grep '"version"' composer.json`
+   - `grep setup_version etc/module.xml`
+3. Decide: **does this release need a data migration** (schema already lives in
+   `etc/db_schema.xml`; this is for *data* changes / one-off tasks run on upgrade)?
+   - **No** → skip step 3 below. This is the common case.
+   - **Yes** → scaffold the patch in step 3.
+
+## Steps
+
+### 1. `composer.json`
+Replace the `version` value. It's a top-level key, near the top of the file:
+```diff
+-    "version": "3.2.2",
++    "version": "X.Y.Z",
+```
+
+### 2. `etc/module.xml`
+Replace `setup_version` on the `<module name="Sequra_Core" ...>` element:
+```diff
+-    <module name="Sequra_Core" setup_version="3.2.2">
++    <module name="Sequra_Core" setup_version="X.Y.Z">
+```
+Leave the `<sequence>` block untouched (that only changes when module dependencies do).
+
+### 3. Data patch — ONLY if a data migration is needed
+Create `Setup/Patch/Data/Version<PACKED>.php`, where **`<PACKED>` is the version with
+dots removed** (`3.3.0` → `Version330`, `3.2.1` → `Version321`). Mirror the existing
+patches exactly (see `Setup/Patch/Data/Version330.php`):
+
+```php
+<?php
+
+namespace Sequra\Core\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use SeQura\Core\Infrastructure\Logger\Logger;
+use Throwable;
+
+class Version<PACKED> implements DataPatchInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private ModuleDataSetupInterface $moduleDataSetup;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(): void
+    {
+        $this->moduleDataSetup->startSetup();
+
+        try {
+            // TODO: the actual migration. Existing patches run a core task, e.g.
+            // (new StoreIntegrationMigrateTask())->execute();
+            // Import the task from SeQura\Core\BusinessLogic\Domain\... and add its
+            // `use` statement above. Remove this block if there's truly nothing to do
+            // (in which case you probably don't need a patch at all).
+
+            Logger::logInfo('Migration ' . self::class . ' has been successfully finished.');
+        } catch (Throwable $e) {
+            // NOTE: the log string uses the DOTTED version, not the packed class suffix.
+            Logger::logError('Update script VX.Y.Z execution failed because: ' . $e->getMessage());
+        }
+
+        $this->moduleDataSetup->endSetup();
+    }
+}
+```
+Conventions to honor:
+- Namespace is **`Sequra\Core\...`** (lowercase `q` — this repo). Imported tasks live
+  under **`SeQura\Core\...`** (capital `Q` — the SDK). Don't mix them up.
+- `getDependencies()` / `getAliases()` return `[]` like the existing patches unless you
+  have a real ordering requirement.
+- The `logError` string uses the dotted `VX.Y.Z`, matching `Version321`/`Version330`.
+
+> Caveat on `<PACKED>`: stripping dots is lossy for multi-digit segments
+> (`3.10.0` → `3100`). It matches the existing convention, but if a segment ever goes
+> double-digit, flag the ambiguity rather than silently colliding.
+
+## Verify (close the loop)
+
+1. **The two anchors match each other and the target** — both must print `X.Y.Z`:
+   ```bash
+   grep '"version"' composer.json
+   grep setup_version etc/module.xml
+   ```
+2. **If you added a patch:** apply it in the running container and confirm it runs clean:
+   ```bash
+   bin/magento setup:upgrade
+   bin/magento cache:flush
+   ```
+   (Requires the Docker env up — see CLAUDE.md. The pre-push hook's phpstan also needs it.)
+3. **Lint stays green** (the new patch file must pass): `bin/phpcs` and, with the env up,
+   `bin/phpstan`.
+4. **Remind the user about the git tag.** The release tag must be `X.Y.Z` so it matches
+   the files — this is what `12f117c` had to fix. State it; do NOT create or push the tag
+   unless explicitly asked (tagging/releasing is an outward action).
+
+## Output discipline
+
+- Touch only the version anchors (+ the one patch file when needed). Don't bump unrelated
+  deps, reformat the files, or edit the `<sequence>` block.
+- Most bumps are just steps 1–2. Don't scaffold a patch "just in case" — an empty patch
+  that does nothing is noise.
+- After changing, list exactly which files you touched and print the two `grep` results so
+  the lockstep is visible.

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,7 @@ tests-e2e export-ignore
 
 # Exclude scripts
 *.sh export-ignore
+
+/CLAUDE.md export-ignore
+/.claude/ export-ignore
+/.githooks/ export-ignore

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,6 +12,12 @@
 #   2. phpcbf then phpcs (Magento2 standard, .phpcs.xml.dist); phpcbf's fixes
 #      are re-staged so they land in the commit.
 #
+# Re-staging caveat: only files phpcbf actually rewrites are `git add`-ed back.
+# If such a file was *partially* staged (`git add -p`, with other hunks left
+# unstaged on purpose), re-staging pulls the whole file — and thus those
+# unstaged hunks — into the commit. The hook warns when this happens; review
+# the diff or bypass with `git commit --no-verify` if it's not what you want.
+#
 # Both steps run in THROWAWAY Docker images — php:7.4-cli-alpine for the syntax
 # lint, php:cli-alpine for phpcs/phpcbf (the same image bin/phpcs uses) — so
 # this hook does NOT need the Magento container running. The heavier gates that
@@ -47,11 +53,38 @@ docker run --rm -v "$PWD":/app -w /app -u "$UIDGID" php:7.4-cli-alpine \
 bin/phpcs-bin/install
 
 echo "▶ PHP Code Beautifier (phpcbf)..."
+# Files that are partially staged (have unstaged working-tree changes too).
+# Recorded BEFORE phpcbf runs so we can warn that re-staging will also commit
+# those unstaged hunks.
+PARTIAL_STAGED=()
+while IFS= read -r -d '' f; do
+    PARTIAL_STAGED+=("$f")
+done < <(git diff --name-only -z -- "${STAGED_PHP[@]}")
+is_partial() { local p; for p in ${PARTIAL_STAGED[@]+"${PARTIAL_STAGED[@]}"}; do [ "$p" = "$1" ] && return 0; done; return 1; }
+
+# Snapshot blob hashes so we re-stage ONLY files phpcbf actually rewrites
+# (parallel array indexed by position — bash 3.2 safe).
+BEFORE_HASHES=()
+for f in "${STAGED_PHP[@]}"; do
+    BEFORE_HASHES+=("$(git hash-object -- "$f" 2>/dev/null || true)")
+done
+
 # phpcbf exits non-zero when it fixes things; phpcs below is the authority.
 docker run --rm -v "$PWD":/app -w /app -u "$UIDGID" php:cli-alpine \
     php bin/phpcs-bin/vendor/bin/phpcbf --standard=.phpcs.xml.dist "${STAGED_PHP[@]}" || true
-# Re-stage whatever phpcbf fixed so the fixes are committed.
-git add -- "${STAGED_PHP[@]}"
+
+# Re-stage only files phpcbf changed. Warn if such a file was partially staged,
+# since re-staging pulls its unstaged hunks into the commit too.
+i=0
+for f in "${STAGED_PHP[@]}"; do
+    if [ "$(git hash-object -- "$f" 2>/dev/null || true)" != "${BEFORE_HASHES[$i]}" ]; then
+        if is_partial "$f"; then
+            echo "  ⚠ $f was partially staged; re-staging phpcbf's fix also stages its other unstaged changes."
+        fi
+        git add -- "$f"
+    fi
+    i=$((i + 1))
+done
 
 echo "▶ PHP_CodeSniffer (phpcs)..."
 docker run --rm -v "$PWD":/app -w /app -u "$UIDGID" php:cli-alpine \

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Sequra_Core pre-commit quality gate (operates on staged .php files).
+#
+# Shipped in the repo and enabled by ./setup.sh via:
+#     git config core.hooksPath .githooks
+# Bypass once with:
+#     git commit --no-verify
+#
+# Checks, in order, on the staged .php files:
+#   1. PHP 7.4 syntax (the language floor — composer.json requires php >=7.4).
+#   2. phpcbf then phpcs (Magento2 standard, .phpcs.xml.dist); phpcbf's fixes
+#      are re-staged so they land in the commit.
+#
+# Both steps run in THROWAWAY Docker images — php:7.4-cli-alpine for the syntax
+# lint, php:cli-alpine for phpcs/phpcbf (the same image bin/phpcs uses) — so
+# this hook does NOT need the Magento container running. The heavier gates that
+# do (the 7.4-8.4 syntax sweep, full phpcs, full phpstan) run in the pre-push
+# hook (.githooks/pre-push), matching CI.
+#
+# phpstan is intentionally NOT run here: it needs the "magento" container with a
+# vendor/ populated by `bin/update-sequra`, and its config analyses container
+# paths — impractical to scope per staged file. pre-push runs it in full.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Staged PHP files (added/copied/modified), NUL-delimited to tolerate spaces.
+STAGED_PHP=()
+while IFS= read -r -d '' f; do
+    STAGED_PHP+=("$f")
+done < <(git diff --cached --name-only --diff-filter=ACM -z -- '*.php')
+
+if [ ${#STAGED_PHP[@]} -eq 0 ]; then
+    echo "No staged PHP files — skipping PHP checks."
+    exit 0
+fi
+
+UIDGID="$(id -u):$(id -g)"
+
+echo "▶ PHP 7.4 syntax check on ${#STAGED_PHP[@]} staged file(s)..."
+docker run --rm -v "$PWD":/app -w /app -u "$UIDGID" php:7.4-cli-alpine \
+    sh -c 'rc=0; for f in "$@"; do php -l -n "$f" >/dev/null || rc=1; done; exit $rc' _ "${STAGED_PHP[@]}"
+
+# Ensure the phpcs toolchain is installed (the same installer bin/phpcs uses).
+bin/phpcs-bin/install
+
+echo "▶ PHP Code Beautifier (phpcbf)..."
+# phpcbf exits non-zero when it fixes things; phpcs below is the authority.
+docker run --rm -v "$PWD":/app -w /app -u "$UIDGID" php:cli-alpine \
+    php bin/phpcs-bin/vendor/bin/phpcbf --standard=.phpcs.xml.dist "${STAGED_PHP[@]}" || true
+# Re-stage whatever phpcbf fixed so the fixes are committed.
+git add -- "${STAGED_PHP[@]}"
+
+echo "▶ PHP_CodeSniffer (phpcs)..."
+docker run --rm -v "$PWD":/app -w /app -u "$UIDGID" php:cli-alpine \
+    php bin/phpcs-bin/vendor/bin/phpcs --standard=.phpcs.xml.dist "${STAGED_PHP[@]}"
+
+echo "✓ Pre-commit checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,8 +27,8 @@
 # phpcs runs in a throwaway image (no container needed); phpstan needs the
 # Docker "magento" service with a vendor/ populated by `bin/update-sequra`. If
 # it isn't running the hook FAILS so unverified code can't be pushed — start it
-# with ./setup.sh or bypass with --no-verify. Git hooks have no TTY, so
-# `docker compose exec -T` is used.
+# with ./setup.sh or bypass with --no-verify. phpstan reuses the bin/phpstan
+# wrapper, which drops the TTY automatically when stdout isn't a terminal.
 
 set -euo pipefail
 
@@ -100,6 +100,6 @@ if ! docker compose exec -T magento true >/dev/null 2>&1; then
     echo "  or bypass with: git push --no-verify"
     exit 1
 fi
-docker compose exec -T magento /bin/bash -c "vendor/bin/phpstan analyse -c /Sequra/Core/phpstan.neon --memory-limit=1G --no-progress"
+bin/phpstan
 
 echo "✓ Pre-push checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Sequra_Core pre-push quality gate — mirrors the CI lint / static-analysis gate.
+#
+# Shipped in the repo and enabled by ./setup.sh via:
+#     git config core.hooksPath .githooks
+# Bypass once with:
+#     git push --no-verify
+#
+# Runs the comprehensive checks that are too heavy (or can't be scoped to
+# staged files) for the pre-commit hook — the same ones CI runs:
+#   1. PHP syntax sweep across every supported version (7.4-8.4) over the pushed
+#      .php files, using throwaway php:<ver>-cli-alpine images (the FIRST push
+#      pulls them). Pre-commit only lints 7.4; this is the full sweep.
+#   2. Full phpcs (Magento2 standard) over the repo — via bin/phpcs.
+#   3. Full phpstan (level 9 over the module) — needs the "magento" container.
+#
+# PHPUnit is intentionally NOT run here: the suite needs a Magento install and
+# double-loads if the module is both installed in Magento and present locally
+# (see Test/README.md) — unsuitable for an automatic hook. It isn't part of the
+# CI lint gate either.
+#
+# The hook inspects the commits being pushed and SKIPS when none touch PHP code
+# or the config that drives the checks (composer.json/lock, phpstan.neon,
+# .phpcs.xml.dist) — a docs-only push runs nothing.
+#
+# phpcs runs in a throwaway image (no container needed); phpstan needs the
+# Docker "magento" service with a vendor/ populated by `bin/update-sequra`. If
+# it isn't running the hook FAILS so unverified code can't be pushed — start it
+# with ./setup.sh or bypass with --no-verify. Git hooks have no TTY, so
+# `docker compose exec -T` is used.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Files whose changes can affect phpcs/phpstan results.
+RELEVANT='\.php$|^composer\.(json|lock)$|^phpstan\.neon$|^\.phpcs\.xml\.dist$'
+
+EMPTY_TREE=$(git hash-object -t tree /dev/null)
+is_zero() { case "$1" in *[!0]*) return 1 ;; *) return 0 ;; esac; }
+
+# Inspect each ref being pushed (git pre-push feeds these on stdin as
+# "<local ref> <local sha> <remote ref> <remote sha>"). Accumulate the changed
+# .php files (added/copied/modified) for the syntax sweep as we go.
+relevant=0
+CHANGED_PHP=()
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    is_zero "$local_sha" && continue            # branch deletion — nothing to check
+
+    if is_zero "$remote_sha"; then
+        # New branch on the remote: diff the commits not yet on any remote.
+        oldest=$(git rev-list "$local_sha" --not --remotes | tail -1)
+        [ -z "$oldest" ] && continue            # nothing new to push
+        if base=$(git rev-parse --quiet --verify "${oldest}^" 2>/dev/null); then :; else
+            base="$EMPTY_TREE"                  # oldest is a root commit
+        fi
+    else
+        base="$remote_sha"
+    fi
+
+    if git diff --name-only "$base" "$local_sha" | grep -qE "$RELEVANT"; then
+        relevant=1
+    fi
+
+    while IFS= read -r -d '' f; do
+        CHANGED_PHP+=("$f")
+    done < <(git diff --name-only --diff-filter=ACM -z "$base" "$local_sha" -- '*.php')
+done
+
+if [ "$relevant" -eq 0 ]; then
+    echo "No PHP-relevant changes in the pushed commits — skipping phpcs/phpstan."
+    exit 0
+fi
+
+# Multi-version syntax sweep over the pushed .php files (7.4-8.4), using
+# throwaway php:<ver>-cli-alpine images. Only files still present in the working
+# tree are linted (php -l needs the content on disk; deletions are skipped).
+PHP_VERSIONS="7.4 8.0 8.1 8.2 8.3 8.4"
+SYNTAX_PHP=()
+for f in ${CHANGED_PHP[@]+"${CHANGED_PHP[@]}"}; do
+    [ -f "$f" ] && SYNTAX_PHP+=("$f")
+done
+if [ ${#SYNTAX_PHP[@]} -gt 0 ]; then
+    echo "▶ PHP syntax sweep (${PHP_VERSIONS// /, }) on ${#SYNTAX_PHP[@]} changed file(s)..."
+    for ver in $PHP_VERSIONS; do
+        echo "  php $ver..."
+        docker run --rm -v "$PWD":/app -w /app "php:${ver}-cli-alpine" \
+            sh -c 'rc=0; for f in "$@"; do php -l -n "$f" >/dev/null || rc=1; done; exit $rc' _ "${SYNTAX_PHP[@]}"
+    done
+fi
+
+echo "▶ PHP_CodeSniffer (full, Magento2 standard)..."
+bin/phpcs -q
+
+echo "▶ PHPStan (full analysis over the module)..."
+if ! docker compose exec -T magento true >/dev/null 2>&1; then
+    echo "✗ Docker 'magento' service is not running — cannot run phpstan."
+    echo "  Start it with ./setup.sh, ensure vendor/ is populated (bin/update-sequra),"
+    echo "  or bypass with: git push --no-verify"
+    exit 1
+fi
+docker compose exec -T magento /bin/bash -c "vendor/bin/phpstan analyse -c /Sequra/Core/phpstan.neon --memory-limit=1G --no-progress"
+
+echo "✓ Pre-push checks passed."

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -51,6 +51,9 @@ jobs:
       - name: PHP 8.4 Syntax check
         run: docker run --rm -v "$(pwd)":/app -w /app php:8.4-cli-alpine sh -c "! (find . -type f -name \"*.php\" ! -path \"./Tests/*\" ! -path \"./vendor/*\" ! -path \"./tests-e2e/*\" ! -path \"./node_modules/*\" ! -path \"./bin/*\" -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"
 
+      - name: PHP 8.5 Syntax check
+        run: docker run --rm -v "$(pwd)":/app -w /app php:8.5-cli-alpine sh -c "! (find . -type f -name \"*.php\" ! -path \"./Tests/*\" ! -path \"./vendor/*\" ! -path \"./tests-e2e/*\" ! -path \"./node_modules/*\" ! -path \"./bin/*\" -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"
+
       - name: PHPCS
         run: |
           chmod +x ./bin/phpcs

--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,14 @@ bin/php/*
 *.gz
 # LLM tooling files (managed by sequcli)
 llm-tooling
-CLAUDE.md
-.claude/
 AGENTS.md
 .opencode/
 opencode.json
+
+# Claude files
+CLAUDE.local.md
+.claude/settings.local.json
+.claude/cache/
+.claude/tmp/
+.claude/logs/
+.claude/artifacts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`Sequra_Core` — the Magento 2 module (`composer` type `magento2-module`, PSR-4 root `Sequra\Core\`) that integrates SeQura payment methods into a Magento store. The module itself is a thin adapter: nearly all business logic lives in the `sequra/integration-core` Composer package (PSR-4 `SeQura\Core\` — note the capital `Q`). This repo implements the Magento-specific *integration interfaces* that core defines, and wires them in via dependency injection.
+
+**Two namespaces, easy to confuse:**
+- `Sequra\Core\...` (lowercase `q`) → this repository.
+- `SeQura\Core\...` (capital `Q`) → the `sequra/integration-core` SDK in `vendor/`, where the domain/business logic lives.
+
+## Architecture
+
+**Bootstrap & service wiring.** `Services/Bootstrap.php` extends core's `BootstrapComponent`. It overrides `initServices()` and `initRepositories()` to register this module's concrete implementations against core's interfaces using `ServiceRegister::registerService(...)` and `RepositoryRegistry::registerRepository(...)`. `Observer/ServiceRegisterObserver.php` triggers `Bootstrap::init()` so the container is populated at runtime. To add a new integration service: implement the core `*ServiceInterface` under `Services/BusinessLogic/`, then register it in `Bootstrap::initServices()`.
+
+**Persistence.** All core entities (`ConnectionData`, `CountryConfiguration`, `GeneralSettings`, `SeQuraOrder`, `PaymentMethod`, `Credentials`, `Deployment`, queue items, etc.) are stored through core's ORM, backed here by `Repository/BaseRepository.php` (generic) and specialized repos like `Repository/SeQuraOrderRepository.php` and `Repository/QueueItemRepository.php`. Schema lives in `etc/db_schema.xml`; data migrations are versioned patches under `Setup/Patch/Data/Version*.php` and `Setup/Patch/Schema/`.
+
+**Payment gateway.** Configured almost entirely declaratively in `etc/di.xml` via Magento's payment-facade virtual types: `SequraPaymentGatewayFacade` (`Magento\Payment\Model\Method\Adapter`), `SequraPaymentGatewayCommandPool` (capture/refund), and the value-handler pool. PHP gateway classes under `Gateway/` (`Request/`, `Http/`, `Response/`) build, transfer, and handle responses for capture/refund/void/order-update against the SeQura API. The payment method code constant is `Sequra\Core\Model\Ui\ConfigProvider::CODE`.
+
+**Checkout payment-methods API.** Frontend checkout fetches available SeQura methods and the payment form through REST endpoints declared in `etc/webapi.xml` (`/V1/sequra_core/...`), served by `Model/Api/` services. There are guest vs. customer variants and a newer `Checkout/` set, wired through `di.xml` virtual types (`Sequra{Customer,Guest}PaymentService`, etc.) with `CartProvider` strategies.
+
+**Controllers.** `Controller/Webhook/` and `Controller/IntegrationWebhook/` receive SeQura callbacks; `Controller/Comeback/` and `Controller/Hpp/` handle the hosted-payment-page return flow; `Controller/AsyncProcess/` runs core's async task queue; `Controller/Adminhtml/Configuration/` backs the admin onboarding/settings UI. CSRF for webhook endpoints is handled by `Plugin/Framework/App/Request/CsrfValidator.php`.
+
+**Admin UI.** The configuration screen is a single-page app shipped as prebuilt assets from the `sequra-core-admin-fe` (a.k.a. `integration-core-ui`) npm package, copied into `view/adminhtml/web/`. Do **not** hand-edit those copied assets — update the package version and re-import (see below).
+
+**Order lifecycle.** `Observer/` hooks Magento order events (cancellation, shipment, address changes) to keep SeQura order state in sync; `Plugin/OrderDetails.php` and the widget plugins augment storefront/admin rendering. Promotional widgets and banners are configured through `Block/Widget*`, `Block/Banner.php`, and `Services/BusinessLogic/PromotionalWidget/`.
+
+## Common commands
+
+This module is developed *inside* a Dockerized Magento install. `./setup.sh --install` boots Magento with the module mounted, then prints the store URL, admin URL, and admin credentials on completion. Those values are read from `.env` (`M2_URL`, `M2_ADMIN_USER`, `M2_ADMIN_PASSWORD`, `M2_HTTP_PORT`, `M2_HTTP_HOST`) — created from `.env.sample` on first run — so don't assume the defaults; read the setup output or your `.env`. The default host requires `127.0.0.1 localhost.sequrapi.com` in `/etc/hosts`. `./teardown.sh` tears it down. All `bin/*` scripts are wrappers that run their tool in the right container/image.
+
+```bash
+bin/magento <args>          # Magento CLI inside the container (e.g. setup:upgrade, cache:flush)
+bin/composer <args>         # Composer inside the container
+bin/update-sequra           # reinstall this module into Magento's vendor/ from the working tree
+bin/update-integration-core-ui   # re-import admin SPA assets after bumping the npm package
+```
+
+**Lint & static analysis (these run in CI — match them before pushing):**
+```bash
+bin/phpcs                   # PHP_CodeSniffer, standard = .phpcs.xml.dist (Magento2 coding standard); add -q for quiet
+bin/phpcbf                  # auto-fix PHPCS violations
+bin/phpstan                 # PHPStan level 9, config phpstan.neon — REQUIRES the docker env running (docker compose exec magento) and bin/update-sequra to have populated vendor/
+```
+CI also runs `php -l` syntax linting across PHP 7.4–8.4. `composer.json` requires `php >=7.4 <8.6`.
+
+**Unit/integration tests** (`Test/`, PHPUnit) run against a Magento install — see `Test/README.md`. Tests autoload core's test base classes from `vendor/sequra/integration-core/tests/...` (see `autoload-dev` in `composer.json`). Note: tests fail if the module is installed in Magento *and* present locally (double-load); rename one folder when running.
+
+**E2E tests** (`tests-e2e/`, Playwright):
+```bash
+bin/playwright              # headless run in the official Playwright Docker image
+bin/playwright --ui         # recommended: UI mode
+bin/playwright --headed
+bin/playwright tests-e2e/specs/example.spec.js   # single spec (path, or bare name)
+```
+E2E requires the container exposed to the internet for SeQura callbacks — run `./setup.sh --ngrok` (or `--cloudflared`) and set `SQ_MERCHANT_REF`, `SQ_USER_SECRET`, `SQ_ASSETS_KEY` in `.env`. Config: `playwright.config.js` (single `chromium` project covering `tests-e2e/specs/`).
+
+## Conventions
+
+- After changing PHP that touches DI, observers, or schema, run `bin/magento setup:upgrade` and `bin/magento cache:flush` in the running container.
+- Versioning: bump `version` in `composer.json` **and** `setup_version` in `etc/module.xml` together (they must match the git tag), and add a `Setup/Patch/Data/Version*.php` patch when data migration is needed.
+- `etc/module.xml` declares load-order `sequence` against Magento core modules — keep it in sync when adding dependencies on other Magento modules.
+- `bin/xdebug --mode=debug|profile|off` toggles XDebug; debug config and SeQura Helper dev webhooks are documented in `README.md`.
+- `phpstan.neon` paths point at `/var/www/html/...` (container paths) and include the dev-only `Sequra/Helper` module from `.docker/`.
+
+## Working style
+
+Behavioral guidelines to reduce common mistakes. These bias toward caution over speed — for trivial tasks, use judgment.
+
+### 1. Think before coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+- State assumptions explicitly; if uncertain, ask. This codebase has sharp edges — the two `Sequra\Core\` vs `SeQura\Core\` namespaces, DI virtual types in `etc/di.xml`, and service registration in `Services/Bootstrap.php`. Confirm which side of an interface you're touching before editing.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop, name what's confusing, and ask.
+
+### 2. Simplicity first
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features, abstractions, or configurability beyond what was asked.
+- Prefer Magento's declarative wiring (`di.xml`, `events.xml`, `db_schema.xml`) over bespoke PHP plumbing. A new integration is usually "implement the core `*ServiceInterface`, register it in `Bootstrap`" — not a new framework.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it. Would a senior Magento engineer call this overcomplicated? If yes, simplify.
+
+### 3. Surgical changes
+
+Touch only what you must. Clean up only your own mess.
+
+- Match the existing style — code must pass `bin/phpcs` (Magento2 standard) and PHPStan level 9 unchanged. Don't reformat adjacent code.
+- Never hand-edit the copied admin SPA assets in `view/adminhtml/web/` — they come from the `sequra-core-admin-fe` npm package; bump the package and re-import instead.
+- Don't refactor things that aren't broken; if you spot unrelated dead code, mention it rather than delete it.
+- Remove only imports/properties/`use` statements that *your* change orphaned.
+- The test: every changed line should trace directly to the request.
+
+### 4. Goal-driven execution
+
+Define success criteria. Loop until verified.
+
+- "Add validation" → write a PHPUnit test (`Test/`) for the invalid input, then make it pass.
+- "Fix the bug" → write a test that reproduces it, then make it pass.
+- "Refactor X" → ensure `bin/phpcs`, `bin/phpstan`, and the tests pass before and after.
+
+For multi-step work, state a brief plan with a verify step each, e.g.:
+```
+1. Implement FooServiceInterface in Services/BusinessLogic → verify: bin/phpstan clean
+2. Register it in Bootstrap::initServices() → verify: bin/magento setup:upgrade + service resolves
+3. Add unit test → verify: PHPUnit green
+```
+Always close the loop with the relevant gate (`bin/phpcs`, `bin/phpstan`, PHPUnit, or `bin/playwright`) — don't declare done on inspection alone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Authoritative standard — read before writing code
+
+`.claude/docs/codingStandard.md` is the **binding coding standard** for this module and the single source of truth; the summaries elsewhere in this file defer to it. **Read it before writing or changing any code.** It covers the module architecture, the integration-core bridge, the **PHP 7.4 syntax floor**, the Magento2 PHPCS standard, and PHPStan level 9.
+
+**The quality gate (non-negotiable):** a change is done only when it passes, in this order, the PHP 7.4–8.5 syntax sweep, then `./bin/phpcs -q`, then `./bin/phpstan` (after `./bin/update-sequra`) — i.e. **`phpcs` → `phpstan` must both pass**, all via the Docker `bin/` wrappers. Don't silence PHPStan; the only sanctioned ignores are Magento's auto-generated factories. For tests, see `Test/README.md`.
+
 ## What this is
 
 `Sequra_Core` — the Magento 2 module (`composer` type `magento2-module`, PSR-4 root `Sequra\Core\`) that integrates SeQura payment methods into a Magento store. The module itself is a thin adapter: nearly all business logic lives in the `sequra/integration-core` Composer package (PSR-4 `SeQura\Core\` — note the capital `Q`). This repo implements the Magento-specific *integration interfaces* that core defines, and wires them in via dependency injection.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The repository includes a docker-compose file to easily test the module. You can
 ```bash
 ./setup.sh --install
 ```
-This will start a Magento 2 instance with the seQura module installed. You can access the admin panel at `http://localhost.sequrapi.com:8018/admin` with the credentials `admin`/`Admin123`.
+This will start a Magento 2 instance with the seQura module installed. The store URL, admin URL, and admin credentials are read from your `.env` file (`M2_URL`, `M2_ADMIN_USER`, `M2_ADMIN_PASSWORD`) and printed in the terminal once the setup completes (see the note below). With the default `.env.sample` values, the admin panel is available at `http://localhost.sequrapi.com:8018/admin` with the credentials `admin`/`Admin123`, but if you customize `.env` use the values shown in your terminal instead.
 
 > [!IMPORTANT]  
 > Make sure you have the line `127.0.0.1	localhost.sequrapi.com` added in your hosts file.

--- a/bin/phpstan
+++ b/bin/phpstan
@@ -1,2 +1,6 @@
 #!/bin/bash
-docker compose exec magento /bin/bash -c "vendor/bin/phpstan analyse -c /Sequra/Core/phpstan.neon --memory-limit=1G --no-progress $@"
+# Drop the TTY when stdout isn't a terminal (e.g. git hooks) so this same
+# wrapper can be reused from .githooks/pre-push without a "not a tty" error.
+TTY=""
+[ -t 1 ] || TTY="-T"
+docker compose exec $TTY magento /bin/bash -c "vendor/bin/phpstan analyse -c /Sequra/Core/phpstan.neon --memory-limit=1G --no-progress $@"

--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,9 @@ open_browser=0
 install=0
 BASEDIR="$(dirname $(realpath $0))"
 
+# Enable the repo's shared git hooks (pre-commit / pre-push quality gates).
+git -C "$BASEDIR" config core.hooksPath .githooks
+
 # Parse arguments:
 # --ngrok-token=YOUR_NGROK_TOKEN: Override the ngrok token in .env
 # --ngrok: Use ngrok to expose the site


### PR DESCRIPTION
### What is the goal?

Set up Claude Code to work effectively in this repository and ship a shared, committed baseline of repo-specific capabilities: architecture guidance, a permission allowlist, automated quality gates that mirror CI, and a version-bump skill tailored to this module's release ritual.

### References
* **Issue:** https://sequra.atlassian.net/browse/PAR-805

### How is it being implemented?

- **`CLAUDE.md`** — documents the architecture (the two `Sequra\Core` vs `SeQura\Core` namespaces, `Bootstrap` service wiring, `di.xml` payment-gateway virtual types, persistence/patches), the Docker-wrapped `bin/*` commands, and the working principles / verify gate.
- **`.claude/settings.json`** — committed permission allowlist for the `bin/*` wrappers and read-only git, with `deny` rules for secrets (`.env*`, `*.pem`, `*.key`) and `ask` gates for outward/destructive actions (`setup.sh`, `teardown.sh`, `git push`).
- **Git quality gates** — `.githooks/pre-commit` (PHP 7.4 syntax + `phpcbf`/`phpcs` scoped to staged files, via throwaway images — no container needed) and `.githooks/pre-push` (multi-version syntax sweep 7.4–8.4 + full `phpcs` + full `phpstan`, mirroring `static-analysis.yml`; skipped when no PHP-relevant changes). Enabled via `setup.sh` setting `core.hooksPath .githooks`.
- **`version-bump` skill** (`.claude/skills/`) — bumps `composer.json` `version` and `etc/module.xml` `setup_version` in lockstep, scaffolds a `Setup/Patch/Data/Version*.php` patch only when a data migration is needed, and reminds that the git tag must match (the desync that `12f117c` had to fix).
- **`.gitignore` / `.gitattributes`** — track the shared `.claude/` config and `.githooks/` while excluding local-only files and keeping all of it out of the Composer/Packagist export (`export-ignore`).

### Caveats

The hooks only activate after running `./setup.sh` (or `git config core.hooksPath .githooks`) once per clone, since `core.hooksPath` is a local git setting that isn't checked in. `pre-push` phpstan additionally requires the `magento` container up with `vendor/` populated by `bin/update-sequra`.

### How is it tested?

No production code changed — this PR adds tooling and configuration only. The new git hooks were exercised on this branch: `pre-push` correctly skipped (`No PHP-relevant changes in the pushed commits`) since the branch touches no `.php` files.

### How is it going to be deployed?

Standard deployment. All added files are dev-only and `export-ignore`d, so nothing ships in the Composer/Packagist dist tarball.
