### PR TITLE
fix: release session lock in admin AJAX config controllers [PAR-821]

### DIFF
--- a/Controller/Adminhtml/Configuration/BaseConfigurationController.php
+++ b/Controller/Adminhtml/Configuration/BaseConfigurationController.php
@@ -89,6 +89,13 @@ class BaseConfigurationController extends Action
         $identifier = $request->getParam('identifier');
         $this->identifier = $identifier;
 
+        // These AJAX actions only read request params and call the SeQura API; they never touch session data.
+        // Release the session write lock now so the onboarding page's parallel requests don't exhaust the
+        // Redis session handler's max_concurrency and fail with "exceeded concurrent connections" (PAR-821).
+        // Admin authentication and ACL have already run during dispatch(), before execute().
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
+        session_write_close();
+
         return $this->$action();
     }
 


### PR DESCRIPTION
## What

`BaseConfigurationController::execute()` now releases the PHP session write lock (`session_write_close()`) right after reading the request params, before dispatching to the AJAX action.

Fixes **[PAR-821](https://sequra.atlassian.net/browse/PAR-821)**.

## Why

`BaseConfigurationController` extends `Magento\Backend\App\Action`, which acquires the session write lock during bootstrap and holds it until the response is sent. The SeQura onboarding page fires several AJAX requests in parallel (`getConnectionData`, `validateConnectionData`, `connect`, `getStores`, `reRegisterWebhooks`, …). Each one held that lock for its full duration — including the external SeQura API calls — so the requests queued on the lock and exhausted the Redis session handler's `max_concurrency` (default 6), failing with:

```
Redis session exceeded concurrent connections
```

None of these actions read or write session data; they only consume request params and the POST body and call the SeQura `AdminAPI`. Admin authentication and ACL already run during `dispatch()`, before `execute()`, so releasing the lock at the start of `execute()` is safe.

## How

A single, central change in the base controller (covers every `*Configuration` AJAX subclass at once):

```php
// phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
session_write_close();
```

placed after the params are read and before `return $this->$action();`. The `phpcs:ignore` matches the existing convention in this same file (`file_get_contents` in `getSequraPostData()`), since `session_*` is on Magento's discouraged-function list.

## Testing / quality gate

- `php -l` — no syntax errors.
- `bin/phpcs` (Magento2 standard) — passes clean on the changed file (exit 0).
- `bin/phpstan` (level 9) — **not run**: the change is a standalone call to the builtin `session_write_close()` with the return discarded (no new types or typed-object calls), so it is level-9-safe by inspection. Happy to run the full gate once the Magento dev env is booted if preferred.

### Manual verification
1. Magento 2.4.x with the Redis session handler and default `max_concurrency`.
2. Open the SeQura onboarding page in the admin.
3. The parallel AJAX requests on page load complete successfully; no `var/report/` entry with "Redis session exceeded concurrent connections".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PAR-821]: https://sequra.atlassian.net/browse/PAR-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ